### PR TITLE
Include ffmpeg in packaged app

### DIFF
--- a/forge.config.ts
+++ b/forge.config.ts
@@ -10,6 +10,7 @@ import { FuseV1Options, FuseVersion } from "@electron/fuses";
 const config: ForgeConfig = {
   packagerConfig: {
     asar: true,
+    extraResource: [".vite/build/ffmpeg"],
   },
   rebuildConfig: {},
   makers: [new MakerSquirrel({}), new MakerZIP({}, ["darwin"]), new MakerRpm({}), new MakerDeb({})],


### PR DESCRIPTION
## Summary
- bundle ffmpeg/ffprobe directory when packaging

## Testing
- `yarn run lint` *(fails: This package doesn't seem to be present in your lockfile)*
- `yarn run test` *(fails: This package doesn't seem to be present in your lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6864b6f0e45c833385dc4fae3fe75f09