### PR TITLE
fix: add mulmocast assets to extraResources for production build

### DIFF
--- a/forge.config.ts
+++ b/forge.config.ts
@@ -10,7 +10,10 @@ import { FuseV1Options, FuseVersion } from "@electron/fuses";
 const config: ForgeConfig = {
   packagerConfig: {
     asar: true,
-    extraResource: [".vite/build/ffmpeg"],
+    extraResource: [
+      ".vite/build/ffmpeg",
+      "node_modules/mulmocast/assets"
+    ],
   },
   rebuildConfig: {},
   makers: [new MakerSquirrel({}), new MakerZIP({}, ["darwin"]), new MakerRpm({}), new MakerDeb({})],

--- a/src/main/mulmo/handler.ts
+++ b/src/main/mulmo/handler.ts
@@ -43,8 +43,8 @@ const isDev = !app.isPackaged;
 if (isDev) {
   updateNpmRoot(path.resolve(__dirname, "../../node_modules/mulmocast"));
 } else {
-  // 本番環境では、extraResourcesにコピーされたmulmocast/assetsを使用
-  updateNpmRoot(path.join(process.resourcesPath, "mulmocast"));
+  // 本番環境では、extraResourcesにコピーされたassetsを使用
+  updateNpmRoot(process.resourcesPath);
 }
 const ffmpegPath = path.resolve(__dirname, "../../node_modules/ffmpeg-ffprobe-static/ffmpeg");
 const ffprobePath = path.resolve(__dirname, "../../node_modules/ffmpeg-ffprobe-static/ffprobe");

--- a/src/main/mulmo/handler.ts
+++ b/src/main/mulmo/handler.ts
@@ -39,7 +39,13 @@ import { app } from "electron";
 
 const isDev = !app.isPackaged;
 
-updateNpmRoot(path.resolve(__dirname, "../../node_modules/mulmocast"));
+// mulmocastのアセットパスを設定
+if (isDev) {
+  updateNpmRoot(path.resolve(__dirname, "../../node_modules/mulmocast"));
+} else {
+  // 本番環境では、extraResourcesにコピーされたmulmocast/assetsを使用
+  updateNpmRoot(path.join(process.resourcesPath, "mulmocast"));
+}
 const ffmpegPath = path.resolve(__dirname, "../../node_modules/ffmpeg-ffprobe-static/ffmpeg");
 const ffprobePath = path.resolve(__dirname, "../../node_modules/ffmpeg-ffprobe-static/ffprobe");
 


### PR DESCRIPTION
  - forge.config.tsにmulmocast/assetsをextraResourcesに追加
  - 本番環境でFFmpegがasar内のアセットファイルにアクセスできない問題を修正
  - handler.tsで本番環境用のmulmocastアセットパスを設定