### PR TITLE
Tab switching should be disabled if the current data is invalid.

### DIFF
--- a/src/renderer/pages/project/components/script_editor.vue
+++ b/src/renderer/pages/project/components/script_editor.vue
@@ -168,13 +168,19 @@ const store = useStore();
 const projectId = computed(() => route.params.id as string);
 
 const currentTab = ref("text");
-
-const mulmoJsonSchema = zodToJsonSchema(mulmoScriptSchema);
+const lastTab = ref("text");
 
 watch(currentTab, () => {
   console.log(currentTab.value);
-  emit("formatAndPushHistoryMulmoScript");
+  if (!props.isValidScript && !["json", "yaml"].includes(currentTab.value)) {
+    currentTab.value = lastTab.value;
+  } else {
+    lastTab.value = currentTab.value;
+    emit("formatAndPushHistoryMulmoScript");
+  }
 });
+
+const mulmoJsonSchema = zodToJsonSchema(mulmoScriptSchema);
 
 const jsonText = ref("");
 const yamlText = ref("");
@@ -192,7 +198,7 @@ const onBlur = () => {
   isEditing.value = false;
 };
 const hasScriptError = computed(() => {
-  return Object.values(props.mulmoError.script ?? {}).flat().length;
+  return Object.values(props.mulmoError?.script ?? {}).flat().length;
 });
 
 watch(isEditing, () => {

--- a/src/renderer/pages/project/components/script_editor.vue
+++ b/src/renderer/pages/project/components/script_editor.vue
@@ -172,7 +172,7 @@ const lastTab = ref("text");
 
 watch(currentTab, () => {
   console.log(currentTab.value);
-  if (!props.isValidScript && !["json", "yaml"].includes(currentTab.value)) {
+  if (!props.isValidScriptData && !["json", "yaml"].includes(currentTab.value)) {
     currentTab.value = lastTab.value;
   } else {
     lastTab.value = currentTab.value;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added validation to prevent switching tabs when the script is invalid, ensuring users can only navigate to "json" or "yaml" tabs in such cases.

* **Bug Fixes**
  * Improved error handling to prevent runtime errors when script errors are undefined or null.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->