### PR TITLE
Divide the image generator into operations for images only, videos on…

### DIFF
--- a/src/main/mulmo/handler.ts
+++ b/src/main/mulmo/handler.ts
@@ -79,13 +79,28 @@ const mulmoCallbackGenerator = (projectId: string, webContents) => {
   };
 };
 
-export const mulmoGenerateImage = async (projectId: string, index: number, webContents) => {
+export const mulmoGenerateImage = async (projectId: string, index: number, target: string, webContents) => {
   const settings = await loadSettings();
   const mulmoCallback = mulmoCallbackGenerator(projectId, webContents);
   addSessionProgressCallback(mulmoCallback);
   try {
     const context = await getContext(projectId);
-    context.force = true;
+
+    const beat = context.studio.script.beats[index];
+    if (target === "image") {
+      context.forceImage = true;
+      beat.moviePrompt = "";
+    }
+    if (target === "movie") {
+      context.forceMovie = true;
+    }
+    if (target === "all") {
+      context.force = true;
+    }
+    if ((target === "movie" || target === "all") && !beat.moviePrompt) {
+      beat.moviePrompt = " ";
+    }
+    console.log(target, beat);
     await generateBeatImage({ index, context, settings });
     removeSessionProgressCallback(mulmoCallback);
   } catch (error) {
@@ -316,7 +331,7 @@ export const mulmoHandler = async (method, webContents, ...args) => {
       case "mulmoActionRunner":
         return await mulmoActionRunner(args[0], args[1], webContents);
       case "mulmoImageGenerate":
-        return await mulmoGenerateImage(args[0], args[1], webContents);
+        return await mulmoGenerateImage(args[0], args[1], args[2], webContents);
       case "mulmoAudioGenerate":
         return await mulmoGenerateAudio(args[0], args[1], webContents);
       case "downloadFile":

--- a/src/renderer/pages/project/components/script_editor.vue
+++ b/src/renderer/pages/project/components/script_editor.vue
@@ -271,8 +271,8 @@ const update = (index: number, path: string, value: unknown) => {
 
 // end of mulmo editor
 
-const generateImage = (index: number) => {
-  emit("generateImage", index);
+const generateImage = (index: number, target: string) => {
+  emit("generateImage", index, target);
   console.log(index);
 };
 const generateAudio = (index: number) => {

--- a/src/renderer/pages/project/components/script_editor/beat_editor.vue
+++ b/src/renderer/pages/project/components/script_editor/beat_editor.vue
@@ -143,9 +143,11 @@
         </div>
         <!-- end of beat.image -->
         <template v-if="shouldShowGenerateButton">
-          <Button variant="outline" size="sm" @click="generateImage()" v-if="!isGenerating" class="mt-4">
-            Generate image
-          </Button>
+          <template v-if="!isGenerating">
+            <Button variant="outline" size="sm" @click="generateImageOnlyImage()" class="mt-4"> Generate image </Button>
+            <Button variant="outline" size="sm" @click="generateImageOnlyMovie()" class="mt-4"> Generate movie </Button>
+            <Button variant="outline" size="sm" @click="generateImage()" class="mt-4"> Generate all </Button>
+          </template>
           <div v-else class="inline-flex items-center whitespace-nowrap">
             <Loader2 class="w-4 h-4 mr-1 animate-spin" />Generating...
           </div>
@@ -156,6 +158,10 @@
       <div>
         <div class="border-2 border-dashed border-gray-300 rounded-lg p-4 text-center">
           <template v-if="beat?.image?.type === 'beat'"> Reference<!-- Todo --> </template>
+          <template v-if="isGenerating">
+            <!-- TODO update design -->
+            <Loader2 class="w-4 h-4 mr-1 animate-spin" />Generating...
+          </template>
           <template v-else-if="imageFile">
             <template v-if="beat?.image?.type === 'movie'">
               <video :size="64" class="mx-auto text-gray-400 mb-4" controls :src="imageFile" />
@@ -316,7 +322,13 @@ const handleDrop = (event: DragEvent, imageType: string) => {
 };
 
 const generateImage = () => {
-  emit("generateImage", props.index);
+  emit("generateImage", props.index, "all");
+};
+const generateImageOnlyImage = () => {
+  emit("generateImage", props.index, "image");
+};
+const generateImageOnlyMovie = () => {
+  emit("generateImage", props.index, "movie");
 };
 
 const update = (path: string, value: unknown) => {

--- a/src/renderer/pages/project/components/script_editor/beat_editor.vue
+++ b/src/renderer/pages/project/components/script_editor/beat_editor.vue
@@ -144,9 +144,12 @@
         <!-- end of beat.image -->
         <template v-if="shouldShowGenerateButton">
           <template v-if="!isGenerating">
-            <Button variant="outline" size="sm" @click="generateImageOnlyImage()" class="mt-4"> Generate image </Button>
-            <Button variant="outline" size="sm" @click="generateImageOnlyMovie()" class="mt-4"> Generate movie </Button>
-            <Button variant="outline" size="sm" @click="generateImage()" class="mt-4"> Generate all </Button>
+            <template v-if="shouldBeGeneratedWithPrompt">
+              <Button variant="outline" size="sm" @click="generateImageOnlyImage()" class="mt-4">Generate image</Button>
+              <Button variant="outline" size="sm" @click="generateImageOnlyMovie()" class="mt-4">Generate movie</Button>
+              <Button variant="outline" size="sm" @click="generateImage()" class="mt-4">Generate all</Button>
+            </template>
+            <Button variant="outline" size="sm" @click="generateImage()" class="mt-4" v-else>Generate image</Button>
           </template>
           <div v-else class="inline-flex items-center whitespace-nowrap">
             <Loader2 class="w-4 h-4 mr-1 animate-spin" />Generating...
@@ -235,6 +238,10 @@ const emit = defineEmits(["update", "generateImage", "positionUp", "deleteBeat"]
 const route = useRoute();
 const store = useStore();
 const projectId = computed(() => route.params.id as string);
+
+const shouldBeGeneratedWithPrompt = computed(() => {
+  return !props.beat.htmlPrompt && !props.beat.image;
+});
 
 const shouldShowGenerateButton = computed(() => {
   return (

--- a/src/renderer/pages/project/project.vue
+++ b/src/renderer/pages/project/project.vue
@@ -144,8 +144,8 @@
                       @update:mulmoValue="store.updateMulmoScript"
                       :isValidScriptData="isValidScriptData"
                       @update:isValidScriptData="(val) => (isValidScriptData = val)"
-                      @generateImage="(val) => generateImage(val)"
-                      @generateAudio="(val) => generateAudio(val)"
+                      @generateImage="generateImage"
+                      @generateAudio="generateAudio"
                       @formatAndPushHistoryMulmoScript="formatAndPushHistoryMulmoScript"
                       :audioFiles="audioFiles"
                       :mulmoError="mulmoError"
@@ -469,9 +469,9 @@ const openProjectFolder = async () => {
   await projectApi.openProjectFolder(projectId.value);
 };
 
-const generateImage = async (index) => {
+const generateImage = async (index: number, target: string) => {
   await saveMulmo(store.currentMulmoScript);
-  await window.electronAPI.mulmoHandler("mulmoImageGenerate", projectId.value, index);
+  await window.electronAPI.mulmoHandler("mulmoImageGenerate", projectId.value, index, target);
   console.log(index);
 };
 const generateAudio = async (index) => {


### PR DESCRIPTION

<img width="393" height="247" alt="button" src="https://github.com/user-attachments/assets/2aae2fb6-ad21-4531-9109-9e636b190be5" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added three distinct buttons in the beat editor for generating an image, a movie, or both, providing more control over generation options.
  * Introduced a loading indicator in the preview area to show progress during generation.

* **Improvements**
  * Enhanced event handling to support specifying the generation type (image, movie, or all) when triggering image generation actions.
  * Updated image generation to handle different targets, improving generation flexibility and context handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->