### PR TITLE
Header stats

### DIFF
--- a/src/renderer/components/header.vue
+++ b/src/renderer/components/header.vue
@@ -27,15 +27,16 @@
         </RouterLink>
 
         <!-- Status indicators -->
-        <div v-if="mockStatus.activeSessionCount > 0" class="flex items-center space-x-1">
+        <div v-if="mulmoEventStore.generatingProjectCount > 0" class="flex items-center space-x-1">
           <Activity :size="16" class="text-green-500" />
-          <Badge variant="secondary" class="text-xs"> {{ mockStatus.activeSessionCount }} generating </Badge>
+          <Badge variant="secondary" class="text-xs"> {{ mulmoEventStore.generatingProjectCount }} generating </Badge>
         </div>
 
-        <div v-if="mockStatus.hasErrors" class="flex items-center space-x-1">
+        <!-- TODO: Add error indicator -->
+        <!-- <div class="flex items-center space-x-1">
           <AlertTriangle :size="16" class="text-red-500" />
           <Badge variant="destructive" class="text-xs"> Errors </Badge>
-        </div>
+        </div> -->
 
         <!-- Hamburger menu for other items -->
         <DropdownMenu>
@@ -76,13 +77,9 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { useMulmoEventStore } from "../store";
 const route = useRoute();
-
-// Mock project status data
-const mockStatus = {
-  activeSessionCount: 2,
-  hasErrors: true,
-};
+const mulmoEventStore = useMulmoEventStore();
 
 const dashboardItem = { path: "/", icon: Home, label: "Dashboard" };
 const menuItems = [

--- a/src/renderer/components/header.vue
+++ b/src/renderer/components/header.vue
@@ -14,18 +14,6 @@
 
       <!-- Navigation -->
       <div class="flex items-center space-x-3">
-        <!-- Dashboard Button - Always visible -->
-        <RouterLink :to="dashboardItem.path">
-          <Button
-            :variant="isDashboardActive ? 'default' : 'ghost'"
-            size="sm"
-            class="relative hover:scale-105 transition-transform duration-200"
-          >
-            <component :is="dashboardItem.icon" :size="16" class="mr-2" />
-            {{ dashboardItem.label }}
-          </Button>
-        </RouterLink>
-
         <!-- Status indicators -->
         <div v-if="mulmoEventStore.generatingProjectCount > 0" class="flex items-center space-x-1">
           <Activity :size="16" class="text-green-500" />
@@ -37,6 +25,18 @@
           <AlertTriangle :size="16" class="text-red-500" />
           <Badge variant="destructive" class="text-xs"> Errors </Badge>
         </div> -->
+
+        <!-- Dashboard Button - Always visible -->
+        <RouterLink :to="dashboardItem.path">
+          <Button
+            :variant="isDashboardActive ? 'default' : 'ghost'"
+            size="sm"
+            class="relative hover:scale-105 transition-transform duration-200"
+          >
+            <component :is="dashboardItem.icon" :size="16" class="mr-2" />
+            {{ dashboardItem.label }}
+          </Button>
+        </RouterLink>
 
         <!-- Hamburger menu for other items -->
         <DropdownMenu>

--- a/src/renderer/components/header.vue
+++ b/src/renderer/components/header.vue
@@ -68,7 +68,7 @@
 <script setup lang="ts">
 import { computed } from "vue";
 import { useRoute } from "vue-router";
-import { Home, Settings, Activity, AlertTriangle, Menu } from "lucide-vue-next";
+import { Home, Settings, Activity, Menu } from "lucide-vue-next";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import {

--- a/src/renderer/components/header.vue
+++ b/src/renderer/components/header.vue
@@ -2,7 +2,7 @@
   <header
     class="bg-white dark:bg-gray-900 border-b border-gray-200 dark:border-gray-800 px-6 py-4 transition-colors duration-200 relative"
   >
-    <div class="max-w-7xl mx-auto flex items-center justify-between">
+    <div class="mx-auto flex items-center justify-between">
       <!-- Logo/Brand -->
       <RouterLink to="/">
         <h1

--- a/src/renderer/store/mulmo_event.ts
+++ b/src/renderer/store/mulmo_event.ts
@@ -1,4 +1,4 @@
-import { ref, computed } from "vue";
+import { ref, computed, watch } from "vue";
 import { defineStore } from "pinia";
 import { MulmoProgressLog } from "../../types";
 import type { SessionType, BeatSessionType, SessionProgressEvent } from "mulmocast";
@@ -62,11 +62,18 @@ export const useMulmoEventStore = defineStore("mulmoEvent", () => {
     }, {});
   });
 
+  const generatingProjectCount = computed(() => {
+    return Object.keys(sessionState.value).filter((projectId) => {
+      return isArtifactGenerating.value[projectId] || isBeatGenerating.value[projectId];
+    }).length;
+  });
+
   return {
     mulmoEvent,
     mulmoLogCallback,
     sessionState,
     isArtifactGenerating,
     isBeatGenerating,
+    generatingProjectCount,
   };
 });

--- a/src/renderer/store/mulmo_event.ts
+++ b/src/renderer/store/mulmo_event.ts
@@ -1,4 +1,4 @@
-import { ref, computed, watch } from "vue";
+import { ref, computed } from "vue";
 import { defineStore } from "pinia";
 import { MulmoProgressLog } from "../../types";
 import type { SessionType, BeatSessionType, SessionProgressEvent } from "mulmocast";


### PR DESCRIPTION
Headerのstatsを修正しました。

- generatingはbeatまたはartifactを生成しているprojectの数を表示
- errorsは一旦非表示（どの単位でのerrorを表示するか不明瞭だったため）
- 表示位置の変更


https://github.com/user-attachments/assets/3c4e6c86-933a-4f50-a173-dd7e5ea43558



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a real-time status indicator in the header to display the number of projects currently generating.
* **Refactor**
  * Updated header layout by removing previous mock status indicators and adjusting container width for improved appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->