### PR TITLE
add badgeToTextArea

### DIFF
--- a/src/renderer/lib/beat_util.ts
+++ b/src/renderer/lib/beat_util.ts
@@ -1,0 +1,20 @@
+export const getBadge = (beat: MulmoBeat) => {
+  if (beat?.image) {
+    if (["image", "movie"].includes(beat.image.type)) {
+      /*
+      if (beat.image?.source?.kind === 'url') {
+        return "Remote File";
+      }
+      */
+      if (beat.image?.source?.kind === "path") {
+        return "Local File";
+      }
+    }
+
+    return beat?.image?.type;
+  }
+  if (beat.htmlPrompt) {
+    return "Html Prompt";
+  }
+  return "Image Prompt";
+};

--- a/src/renderer/lib/beat_util.ts
+++ b/src/renderer/lib/beat_util.ts
@@ -8,7 +8,7 @@ export const getBadge = (beat: MulmoBeat) => {
         return "Remote File";
       }
       */
-      if (beat.image?.source?.kind === "path") {
+      if ("source" in beat.image && beat.image?.source?.kind === "path") {
         return "Local File";
       }
     }

--- a/src/renderer/lib/beat_util.ts
+++ b/src/renderer/lib/beat_util.ts
@@ -1,3 +1,5 @@
+import type { MulmoBeat } from "mulmocast/browser";
+
 export const getBadge = (beat: MulmoBeat) => {
   if (beat?.image) {
     if (["image", "movie"].includes(beat.image.type)) {

--- a/src/renderer/pages/project/components/script_editor.vue
+++ b/src/renderer/pages/project/components/script_editor.vue
@@ -29,7 +29,10 @@
 
           <div v-for="(beat, index) in safeBeats ?? []" :key="index">
             <Card class="p-4 space-y-1 gap-2">
-              <div class="font-bold text-gray-700">Beat {{ index + 1 }}</div>
+              <div class="font-bold text-gray-700 flex justify-between items-center">
+                <span>Beat {{ index + 1 }}</span>
+                <Badge variant="outline">{{ getBadge(beat) }}</Badge>
+              </div>
               <div>
                 <Label>Speaker</Label>
                 <Input
@@ -148,6 +151,7 @@ import { ref, computed, watch } from "vue";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Card } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
 import BeatEditor from "./script_editor/beat_editor.vue";
@@ -165,6 +169,8 @@ import { MulmoError } from "../../../../types";
 import { removeEmptyValues } from "@/lib/utils";
 import { arrayPositionUp, arrayInsertAfter, arrayRemoveAt } from "@/lib/array";
 import { SCRIPT_EDITOR_TABS, type ScriptEditorTab } from "../../../../shared/constants";
+
+import { getBadge } from "@/lib/beat_util.js";
 
 interface Props {
   mulmoValue: MulmoScript;

--- a/src/renderer/pages/project/components/script_editor/beat_editor.vue
+++ b/src/renderer/pages/project/components/script_editor/beat_editor.vue
@@ -253,6 +253,8 @@ import { useRoute } from "vue-router";
 import BeatAdd from "./beat_add.vue";
 import MediaModal from "@/components/media_modal.vue";
 
+import { getBadge } from "@/lib/beat_util.js";
+
 interface Props {
   beat: MulmoBeat;
   index: number;
@@ -326,27 +328,6 @@ const getPromptLabel = (beat: MulmoBeat) => {
       default:
         return "Prompt";
     }
-  }
-  if (beat.htmlPrompt) {
-    return "Html Prompt";
-  }
-  return "Image Prompt";
-};
-
-const getBadge = (beat: MulmoBeat) => {
-  if (beat?.image) {
-    if (["image", "movie"].includes(beat.image.type)) {
-      /*
-      if (beat.image?.source?.kind === 'url') {
-        return "Remote File";
-      }
-      */
-      if (beat.image?.source?.kind === "path") {
-        return "Local File";
-      }
-    }
-
-    return beat?.image?.type;
   }
   if (beat.htmlPrompt) {
     return "Html Prompt";


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added badges next to beat numbers in the script editor's Text tab to indicate the type or source of each beat's image or prompt.

* **Refactor**
  * Centralized badge generation logic for beats, ensuring consistent badge display across components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->