### PR TITLE
Refactor beat editor UI layout (Text/Media tab) with floating control buttons and consistent spacing

### DIFF
--- a/src/renderer/pages/project/components/script_editor.vue
+++ b/src/renderer/pages/project/components/script_editor.vue
@@ -145,7 +145,6 @@
                 @generateImage="generateImage"
                 @deleteBeat="deleteBeat"
                 @positionUp="positionUp"
-                @addBeat="addBeat"
               />
             </Card>
             <div class="px-4 pt-4">

--- a/src/renderer/pages/project/components/script_editor.vue
+++ b/src/renderer/pages/project/components/script_editor.vue
@@ -22,7 +22,7 @@
         class="border rounded-lg p-4 bg-gray-50 min-h-[400px] max-h-[calc(100vh-340px)] overflow-y-auto font-mono text-sm space-y-6"
       >
         <p class="text-sm text-gray-500 mb-2">Text Mode - Speaker and dialogue editing only</p>
-        <div class="space-y-6 mx-auto">
+        <div class="space-y-2 mx-auto">
           <div class="px-2 py-1">
             <BeatAdd @addBeat="(beat) => addBeat(beat, -1)" />
           </div>
@@ -71,7 +71,7 @@
                 class="w-5 h-5 text-gray-500 hover:text-red-500 cursor-pointer transition"
               />
             </div>
-            <div class="px-4 pt-4">
+            <div class="px-4 pt-2">
               <BeatAdd @addBeat="(beat) => addBeat(beat, index)" />
             </div>
           </div>
@@ -126,7 +126,7 @@
       <div class="border rounded-lg p-4 bg-gray-50 min-h-[400px] max-h-[calc(100vh-340px)] overflow-y-auto">
         <p class="text-sm text-gray-500 mb-2">Media Mode - Beat-by-beat media editing and preview</p>
 
-        <div class="space-y-4 mx-auto">
+        <div class="space-y-2 mx-auto">
           <div class="px-2 py-1">
             <BeatAdd @addBeat="(beat) => addBeat(beat, -1)" />
           </div>
@@ -160,7 +160,7 @@
                 class="w-5 h-5 text-gray-500 hover:text-red-500 cursor-pointer transition"
               />
             </div>
-            <div class="px-4 pt-4">
+            <div class="px-4 pt-2">
               <BeatAdd @addBeat="(beat) => addBeat(beat, index)" />
             </div>
           </div>

--- a/src/renderer/pages/project/components/script_editor.vue
+++ b/src/renderer/pages/project/components/script_editor.vue
@@ -55,7 +55,9 @@
               <span v-if="mulmoEventStore.sessionState?.[projectId]?.['beat']?.['audio']?.[index]">generating</span>
               <audio :src="audioFiles[index]" v-if="!!audioFiles[index]" controls />
             </Card>
-            <div class="absolute -top-5 right-0 z-10 flex items-center gap-3 px-2 py-1 rounded border border-gray-300 bg-white shadow-sm">
+            <div
+              class="absolute -top-5 right-0 z-10 flex items-center gap-3 px-2 py-1 rounded border border-gray-300 bg-white shadow-sm"
+            >
               <ArrowUp
                 v-if="index !== 0"
                 @click="() => positionUp(index)"
@@ -144,7 +146,9 @@
                 @generateImage="generateImage"
               />
             </Card>
-            <div class="absolute -top-5 right-0 z-10 flex items-center gap-3 px-2 py-1 rounded border border-gray-300 bg-white shadow-sm">
+            <div
+              class="absolute -top-5 right-0 z-10 flex items-center gap-3 px-2 py-1 rounded border border-gray-300 bg-white shadow-sm"
+            >
               <ArrowUp
                 v-if="index !== 0"
                 @click="() => positionUp(index)"

--- a/src/renderer/pages/project/components/script_editor.vue
+++ b/src/renderer/pages/project/components/script_editor.vue
@@ -132,7 +132,7 @@
             <BeatAdd @addBeat="(beat) => addBeat(beat, -1)" />
           </div>
 
-          <div v-for="(beat, index) in safeBeats" :key="beat?.id ?? index">
+          <div v-for="(beat, index) in safeBeats" :key="beat?.id ?? index" class="relative">
             <Card class="p-4">
               <BeatEditor
                 :beat="beat"
@@ -143,10 +143,24 @@
                 :mulmoError="mulmoError?.['beats']?.[index] ?? []"
                 @update="update"
                 @generateImage="generateImage"
-                @deleteBeat="deleteBeat"
-                @positionUp="positionUp"
               />
             </Card>
+            <div class="absolute -top-5 right-0 z-10 flex items-center gap-3 px-2 py-1 rounded border border-gray-300 bg-white shadow-sm">
+              <ArrowUp
+                v-if="index !== 0"
+                @click="() => positionUp(index)"
+                class="w-5 h-5 text-gray-500 hover:text-blue-500 cursor-pointer transition"
+              />
+              <ArrowDown
+                v-if="(mulmoValue?.beats ?? []).length !== index + 1"
+                @click="() => positionUp(index + 1)"
+                class="w-5 h-5 text-gray-500 hover:text-blue-500 cursor-pointer transition"
+              />
+              <Trash
+                @click="deleteBeat(index)"
+                class="w-5 h-5 text-gray-500 hover:text-red-500 cursor-pointer transition"
+              />
+            </div>
             <div class="px-4 pt-4">
               <BeatAdd @addBeat="(beat) => addBeat(beat, index)" />
             </div>

--- a/src/renderer/pages/project/components/script_editor.vue
+++ b/src/renderer/pages/project/components/script_editor.vue
@@ -27,7 +27,7 @@
             <BeatAdd @addBeat="(beat) => addBeat(beat, -1)" />
           </div>
 
-          <div v-for="(beat, index) in safeBeats ?? []" :key="index">
+          <div v-for="(beat, index) in safeBeats ?? []" :key="index" class="relative">
             <Card class="p-4 space-y-1 gap-2">
               <div class="font-bold text-gray-700 flex justify-between items-center">
                 <span>Beat {{ index + 1 }}</span>
@@ -54,24 +54,23 @@
               <Button variant="outline" size="sm" @click="generateAudio(index)" class="w-fit">generate audio</Button>
               <span v-if="mulmoEventStore.sessionState?.[projectId]?.['beat']?.['audio']?.[index]">generating</span>
               <audio :src="audioFiles[index]" v-if="!!audioFiles[index]" controls />
-
-              <div class="flex items-center gap-1 px-2 py-1 pr-3">
-                <ArrowUp
-                  v-if="index !== 0"
-                  @click="() => positionUp(index)"
-                  class="w-5 h-5 text-gray-500 hover:text-blue-500 cursor-pointer transition"
-                />
-                <ArrowDown
-                  v-if="(mulmoValue?.beats ?? []).length !== index + 1"
-                  @click="() => positionUp(index + 1)"
-                  class="w-5 h-5 text-gray-500 hover:text-blue-500 cursor-pointer transition"
-                />
-                <Trash
-                  @click="deleteBeat(index)"
-                  class="w-5 h-5 text-gray-500 hover:text-red-500 cursor-pointer transition"
-                />
-              </div>
             </Card>
+            <div class="absolute -top-5 right-0 z-10 flex items-center gap-3 px-2 py-1 rounded border border-gray-300 bg-white shadow-sm">
+              <ArrowUp
+                v-if="index !== 0"
+                @click="() => positionUp(index)"
+                class="w-5 h-5 text-gray-500 hover:text-blue-500 cursor-pointer transition"
+              />
+              <ArrowDown
+                v-if="(mulmoValue?.beats ?? []).length !== index + 1"
+                @click="() => positionUp(index + 1)"
+                class="w-5 h-5 text-gray-500 hover:text-blue-500 cursor-pointer transition"
+              />
+              <Trash
+                @click="deleteBeat(index)"
+                class="w-5 h-5 text-gray-500 hover:text-red-500 cursor-pointer transition"
+              />
+            </div>
             <div class="px-4 pt-4">
               <BeatAdd @addBeat="(beat) => addBeat(beat, index)" />
             </div>

--- a/src/renderer/pages/project/components/script_editor.vue
+++ b/src/renderer/pages/project/components/script_editor.vue
@@ -127,26 +127,31 @@
       <div class="border rounded-lg p-4 bg-gray-50 min-h-[400px] max-h-[calc(100vh-340px)] overflow-y-auto">
         <p class="text-sm text-gray-500 mb-2">Media Mode - Beat-by-beat media editing and preview</p>
 
-        <div class="space-y-4">
-          <Card class="px-4">
+        <div class="space-y-4 mx-auto">
+          <div class="px-2 py-1">
             <BeatAdd @addBeat="(beat) => addBeat(beat, -1)" />
-          </Card>
+          </div>
 
-          <Card v-for="(beat, index) in safeBeats" :key="beat?.id ?? index" class="p-4">
-            <BeatEditor
-              :beat="beat"
-              :index="index"
-              :isEnd="(mulmoValue?.beats ?? []).length === index + 1"
-              :imageFile="imageFiles[index]"
-              :movieFile="movieFiles[index]"
-              :mulmoError="mulmoError?.['beats']?.[index] ?? []"
-              @update="update"
-              @generateImage="generateImage"
-              @deleteBeat="deleteBeat"
-              @positionUp="positionUp"
-              @addBeat="addBeat"
-            />
-          </Card>
+          <div v-for="(beat, index) in safeBeats" :key="beat?.id ?? index">
+            <Card class="p-4">
+              <BeatEditor
+                :beat="beat"
+                :index="index"
+                :isEnd="(mulmoValue?.beats ?? []).length === index + 1"
+                :imageFile="imageFiles[index]"
+                :movieFile="movieFiles[index]"
+                :mulmoError="mulmoError?.['beats']?.[index] ?? []"
+                @update="update"
+                @generateImage="generateImage"
+                @deleteBeat="deleteBeat"
+                @positionUp="positionUp"
+                @addBeat="addBeat"
+              />
+            </Card>
+            <div class="px-4 pt-4">
+              <BeatAdd @addBeat="(beat) => addBeat(beat, index)" />
+            </div>
+          </div>
         </div>
       </div>
     </TabsContent>

--- a/src/renderer/pages/project/components/script_editor/beat_editor.vue
+++ b/src/renderer/pages/project/components/script_editor/beat_editor.vue
@@ -215,10 +215,7 @@
         {{ error }}
       </div>
     </div>
-    <div class="flex justify-between mt-2 py-1 rounded border border-gray-300">
-      <div class="px-2 py-1">
-        <BeatAdd @addBeat="addBeat" />
-      </div>
+    <div class="flex justify-end mt-2 py-1 rounded border border-gray-300">
       <div class="flex items-center gap-1 px-2 py-1 pr-3">
         <ArrowUp
           v-if="index !== 0"
@@ -250,7 +247,6 @@ import type { MulmoBeat } from "mulmocast/browser";
 
 import { useMulmoEventStore } from "../../../../store";
 import { useRoute } from "vue-router";
-import BeatAdd from "./beat_add.vue";
 import MediaModal from "@/components/media_modal.vue";
 
 import { getBadge } from "@/lib/beat_util.js";
@@ -265,7 +261,7 @@ interface Props {
 }
 
 const props = defineProps<Props>();
-const emit = defineEmits(["update", "generateImage", "positionUp", "deleteBeat", "addBeat"]);
+const emit = defineEmits(["update", "generateImage", "positionUp", "deleteBeat"]);
 
 const route = useRoute();
 const mulmoEventStore = useMulmoEventStore();
@@ -409,10 +405,6 @@ const positionDown = () => {
 };
 const trash = () => {
   emit("deleteBeat", props.index);
-};
-
-const addBeat = (beat: MulmoBeat) => {
-  emit("addBeat", beat, props.index);
 };
 
 const getMediaSrc = (file: ArrayBuffer | string | null): string => {

--- a/src/renderer/pages/project/components/script_editor/beat_editor.vue
+++ b/src/renderer/pages/project/components/script_editor/beat_editor.vue
@@ -215,21 +215,6 @@
         {{ error }}
       </div>
     </div>
-    <div class="flex justify-end mt-2 py-1 rounded border border-gray-300">
-      <div class="flex items-center gap-1 px-2 py-1 pr-3">
-        <ArrowUp
-          v-if="index !== 0"
-          @click="positionUp"
-          class="w-5 h-5 text-gray-500 hover:text-blue-500 cursor-pointer transition"
-        />
-        <ArrowDown
-          v-if="!isEnd"
-          @click="positionDown"
-          class="w-5 h-5 text-gray-500 hover:text-blue-500 cursor-pointer transition"
-        />
-        <Trash @click="trash" class="w-5 h-5 text-gray-500 hover:text-red-500 cursor-pointer transition" />
-      </div>
-    </div>
 
     <MediaModal v-model:open="modalOpen" :type="modalType" :src="modalSrc" />
   </div>
@@ -242,7 +227,7 @@ import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
-import { FileImage, Video, Loader2, ArrowUp, ArrowDown, Trash } from "lucide-vue-next";
+import { FileImage, Video, Loader2 } from "lucide-vue-next";
 import type { MulmoBeat } from "mulmocast/browser";
 
 import { useMulmoEventStore } from "../../../../store";
@@ -261,7 +246,7 @@ interface Props {
 }
 
 const props = defineProps<Props>();
-const emit = defineEmits(["update", "generateImage", "positionUp", "deleteBeat"]);
+const emit = defineEmits(["update", "generateImage"]);
 
 const route = useRoute();
 const mulmoEventStore = useMulmoEventStore();
@@ -395,16 +380,6 @@ const generateImageOnlyMovie = () => {
 
 const update = (path: string, value: unknown) => {
   emit("update", props.index, path, value);
-};
-
-const positionUp = () => {
-  emit("positionUp", props.index);
-};
-const positionDown = () => {
-  emit("positionUp", props.index + 1);
-};
-const trash = () => {
-  emit("deleteBeat", props.index);
 };
 
 const getMediaSrc = (file: ArrayBuffer | string | null): string => {


### PR DESCRIPTION
## 概要
  - BeatAdd を独立化し、枠線を削除しました
  - 各beatカードの右上に浮かぶコントロールボタン（矢印・ゴミ箱）を配置しました
    - Insert ボタンの右側の余白を活用するため、「その枠の右外に置き、」ではなく、右上としました。 
  - 縦方向のマージンを調整しました

<img width="1030" height="1422" alt="CleanShot 2025-07-18 at 15 57 32@2x" src="https://github.com/user-attachments/assets/939d1379-e62f-4696-bb0e-82755b9d6600" />

-- 以下、Claude 作成し、西井にて確認済み。 --

  ## 主な変更内容
  - **BeatAddコンポーネントの独立化**:
  BeatEditor内部からBeatAddを分離し、各beat間に独立して配置
  - **コントロールボタンの浮遊配置**:
  矢印とゴミ箱ボタンを各beatカードの右上に絶対位置で配置
  - **一貫したスタイリング**: 白い背景、境界線、影効果を適用し、視認性を向上
  - **マージンの最適化**: 縦方向のマージンを調整し、より効率的な画面利用を実現

  ## 技術的な詳細
  - `absolute -top-5 right-0 z-10`を使用したコントロールボタンの配置
  - `gap-3`によるアイコン間の適切な間隔設定
  - `space-y-2`と`pt-2`による縦マージンの統一化
  - TEXTタブとMEDIAタブでの完全一致したレイアウト構造

  ## 影響範囲
  - `script_editor.vue`: メインのエディターレイアウト変更
  - `beat_editor.vue`: 内部コントロールボタンの削除とクリーンアップ

  この変更により、両タブで一貫したユーザーエクスペリエンスを提供し、より効率的な編集作業
  を可能にします。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved the layout and appearance of beat controls in the script editor for both Text and Media modes, with more compact spacing and visually distinct control buttons.

* **Refactor**
  * Removed beat addition, reordering, and deletion controls from the beat editor component to streamline the interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->