### PR TITLE
TransitionGroup animations for beat list operations

### DIFF
--- a/src/renderer/pages/project/components/script_editor.vue
+++ b/src/renderer/pages/project/components/script_editor.vue
@@ -27,9 +27,9 @@
             <BeatAdd @addBeat="(beat) => addBeat(beat, -1)" />
           </div>
 
-          <TransitionGroup 
-            name="beat-list" 
-            tag="div" 
+          <TransitionGroup
+            name="beat-list"
+            tag="div"
             class="space-y-2"
             enter-active-class="transition-all duration-300 ease-out"
             enter-from-class="opacity-0 translate-y-2 scale-95"
@@ -144,9 +144,9 @@
             <BeatAdd @addBeat="(beat) => addBeat(beat, -1)" />
           </div>
 
-          <TransitionGroup 
-            name="beat-list" 
-            tag="div" 
+          <TransitionGroup
+            name="beat-list"
+            tag="div"
             class="space-y-2"
             enter-active-class="transition-all duration-300 ease-out"
             enter-from-class="opacity-0 translate-y-2 scale-95"
@@ -154,7 +154,7 @@
             leave-to-class="opacity-0 translate-y-2 scale-95"
             move-class="transition-all duration-300 ease-in-out"
           >
-            <div v-for="(beat, index) in safeBeats" :key="beat?.id ?? index" class="relative">          
+            <div v-for="(beat, index) in safeBeats" :key="beat?.id ?? index" class="relative">
               <Card class="p-4">
                 <BeatEditor
                   :beat="beat"

--- a/src/renderer/pages/project/components/script_editor.vue
+++ b/src/renderer/pages/project/components/script_editor.vue
@@ -37,7 +37,7 @@
             leave-to-class="opacity-0 translate-y-2 scale-95"
             move-class="transition-all duration-300 ease-in-out"
           >
-            <div v-for="(beat, index) in safeBeats" :key="beat?.id || `beat-${index}`" class="relative">
+            <div v-for="(beat, index) in safeBeats ?? []" :key="index" class="relative">
               <Card class="p-4 space-y-1 gap-2">
                 <div class="font-bold text-gray-700 flex justify-between items-center">
                   <span>Beat {{ index + 1 }}</span>
@@ -154,7 +154,7 @@
             leave-to-class="opacity-0 translate-y-2 scale-95"
             move-class="transition-all duration-300 ease-in-out"
           >
-            <div v-for="(beat, index) in safeBeats" :key="beat?.id || `beat-${index}`" class="relative">          
+            <div v-for="(beat, index) in safeBeats" :key="beat?.id ?? index" class="relative">          
               <Card class="p-4">
                 <BeatEditor
                   :beat="beat"

--- a/src/renderer/pages/project/components/script_editor.vue
+++ b/src/renderer/pages/project/components/script_editor.vue
@@ -37,7 +37,7 @@
             leave-to-class="opacity-0 translate-y-2 scale-95"
             move-class="transition-all duration-300 ease-in-out"
           >
-            <div v-for="(beat, index) in safeBeats ?? []" :key="index" class="relative">
+            <div v-for="(beat, index) in beatsWithTempId" :key="beat._tempId" class="relative">
               <Card class="p-4 space-y-1 gap-2">
                 <div class="font-bold text-gray-700 flex justify-between items-center">
                   <span>Beat {{ index + 1 }}</span>
@@ -154,7 +154,7 @@
             leave-to-class="opacity-0 translate-y-2 scale-95"
             move-class="transition-all duration-300 ease-in-out"
           >
-            <div v-for="(beat, index) in safeBeats" :key="beat?.id ?? index" class="relative">          
+            <div v-for="(beat, index) in beatsWithTempId" :key="beat._tempId" class="relative">          
               <Card class="p-4">
                 <BeatEditor
                   :beat="beat"
@@ -265,7 +265,22 @@ const currentTab = ref<ScriptEditorTab>(props.scriptEditorActiveTab || SCRIPT_ED
 const lastTab = ref<ScriptEditorTab>(props.scriptEditorActiveTab || SCRIPT_EDITOR_TABS.TEXT);
 
 const safeBeats = computed(() => {
-  return props.mulmoValue?.beats ?? [];
+  const beats = props.mulmoValue?.beats ?? [];
+  console.log("=== BEATS STATUS ===");
+  console.log("Total beats:", beats.length);
+  beats.forEach((beat, i) => {
+    const tempId = beat.id || `temp-${i}-${beat.text?.slice(0,10) || 'empty'}`;
+    console.log(`Beat ${i}: id=${beat.id || 'NO_ID'}, tempId=${tempId}, text="${beat.text?.slice(0, 20) || 'empty'}..."`);
+  });
+  console.log("==================");
+  return beats;
+});
+
+const beatsWithTempId = computed(() => {
+  return safeBeats.value.map((beat, index) => ({
+    ...beat,
+    _tempId: beat.id || `temp-${index}-${beat.text?.slice(0,10) || 'empty'}`
+  }));
 });
 
 watch(currentTab, () => {

--- a/src/renderer/pages/project/components/script_editor.vue
+++ b/src/renderer/pages/project/components/script_editor.vue
@@ -144,41 +144,52 @@
             <BeatAdd @addBeat="(beat) => addBeat(beat, -1)" />
           </div>
 
-          <div v-for="(beat, index) in safeBeats" :key="beat?.id ?? index" class="relative">
-            <Card class="p-4">
-              <BeatEditor
-                :beat="beat"
-                :index="index"
-                :isEnd="(mulmoValue?.beats ?? []).length === index + 1"
-                :imageFile="imageFiles[index]"
-                :movieFile="movieFiles[index]"
-                :mulmoError="mulmoError?.['beats']?.[index] ?? []"
-                @update="update"
-                @generateImage="generateImage"
-              />
-            </Card>
-            <div
-              class="absolute -top-5 right-0 z-10 flex items-center gap-3 px-2 py-1 rounded border border-gray-300 bg-white shadow-sm"
-            >
-              <ArrowUp
-                v-if="index !== 0"
-                @click="() => positionUp(index)"
-                class="w-5 h-5 text-gray-500 hover:text-blue-500 cursor-pointer transition"
-              />
-              <ArrowDown
-                v-if="(mulmoValue?.beats ?? []).length !== index + 1"
-                @click="() => positionUp(index + 1)"
-                class="w-5 h-5 text-gray-500 hover:text-blue-500 cursor-pointer transition"
-              />
-              <Trash
-                @click="deleteBeat(index)"
-                class="w-5 h-5 text-gray-500 hover:text-red-500 cursor-pointer transition"
-              />
+          <TransitionGroup 
+            name="beat-list" 
+            tag="div" 
+            class="space-y-2"
+            enter-active-class="transition-all duration-300 ease-out"
+            enter-from-class="opacity-0 translate-y-2 scale-95"
+            leave-active-class="transition-all duration-300 ease-in"
+            leave-to-class="opacity-0 translate-y-2 scale-95"
+            move-class="transition-all duration-300 ease-in-out"
+          >
+            <div v-for="(beat, index) in safeBeats" :key="beat?.id || `beat-${index}`" class="relative">          
+              <Card class="p-4">
+                <BeatEditor
+                  :beat="beat"
+                  :index="index"
+                  :isEnd="(mulmoValue?.beats ?? []).length === index + 1"
+                  :imageFile="imageFiles[index]"
+                  :movieFile="movieFiles[index]"
+                  :mulmoError="mulmoError?.['beats']?.[index] ?? []"
+                  @update="update"
+                  @generateImage="generateImage"
+                />
+              </Card>
+              <div
+                class="absolute -top-5 right-0 z-10 flex items-center gap-3 px-2 py-1 rounded border border-gray-300 bg-white shadow-sm"
+              >
+                <ArrowUp
+                  v-if="index !== 0"
+                  @click="() => positionUp(index)"
+                  class="w-5 h-5 text-gray-500 hover:text-blue-500 cursor-pointer transition"
+                />
+                <ArrowDown
+                  v-if="(mulmoValue?.beats ?? []).length !== index + 1"
+                  @click="() => positionUp(index + 1)"
+                  class="w-5 h-5 text-gray-500 hover:text-blue-500 cursor-pointer transition"
+                />
+                <Trash
+                  @click="deleteBeat(index)"
+                  class="w-5 h-5 text-gray-500 hover:text-red-500 cursor-pointer transition"
+                />
+              </div>
+              <div class="px-4 pt-2">
+                <BeatAdd @addBeat="(beat) => addBeat(beat, index)" />
+              </div>
             </div>
-            <div class="px-4 pt-2">
-              <BeatAdd @addBeat="(beat) => addBeat(beat, index)" />
-            </div>
-          </div>
+          </TransitionGroup>
         </div>
       </div>
     </TabsContent>

--- a/src/renderer/pages/project/components/script_editor.vue
+++ b/src/renderer/pages/project/components/script_editor.vue
@@ -37,7 +37,7 @@
             leave-to-class="opacity-0 translate-y-2 scale-95"
             move-class="transition-all duration-300 ease-in-out"
           >
-            <div v-for="(beat, index) in beatsWithTempId" :key="beat._tempId" class="relative">
+            <div v-for="(beat, index) in safeBeats ?? []" :key="index" class="relative">
               <Card class="p-4 space-y-1 gap-2">
                 <div class="font-bold text-gray-700 flex justify-between items-center">
                   <span>Beat {{ index + 1 }}</span>
@@ -154,7 +154,7 @@
             leave-to-class="opacity-0 translate-y-2 scale-95"
             move-class="transition-all duration-300 ease-in-out"
           >
-            <div v-for="(beat, index) in beatsWithTempId" :key="beat._tempId" class="relative">          
+            <div v-for="(beat, index) in safeBeats" :key="beat?.id ?? index" class="relative">          
               <Card class="p-4">
                 <BeatEditor
                   :beat="beat"
@@ -265,22 +265,7 @@ const currentTab = ref<ScriptEditorTab>(props.scriptEditorActiveTab || SCRIPT_ED
 const lastTab = ref<ScriptEditorTab>(props.scriptEditorActiveTab || SCRIPT_EDITOR_TABS.TEXT);
 
 const safeBeats = computed(() => {
-  const beats = props.mulmoValue?.beats ?? [];
-  console.log("=== BEATS STATUS ===");
-  console.log("Total beats:", beats.length);
-  beats.forEach((beat, i) => {
-    const tempId = beat.id || `temp-${i}-${beat.text?.slice(0,10) || 'empty'}`;
-    console.log(`Beat ${i}: id=${beat.id || 'NO_ID'}, tempId=${tempId}, text="${beat.text?.slice(0, 20) || 'empty'}..."`);
-  });
-  console.log("==================");
-  return beats;
-});
-
-const beatsWithTempId = computed(() => {
-  return safeBeats.value.map((beat, index) => ({
-    ...beat,
-    _tempId: beat.id || `temp-${index}-${beat.text?.slice(0,10) || 'empty'}`
-  }));
+  return props.mulmoValue?.beats ?? [];
 });
 
 watch(currentTab, () => {

--- a/src/renderer/pages/project/components/script_editor.vue
+++ b/src/renderer/pages/project/components/script_editor.vue
@@ -37,7 +37,7 @@
             leave-to-class="opacity-0 translate-y-2 scale-95"
             move-class="transition-all duration-300 ease-in-out"
           >
-            <div v-for="(beat, index) in safeBeats ?? []" :key="index" class="relative">
+            <div v-for="(beat, index) in safeBeats ?? []" :key="beat?.id ?? index" class="relative">
               <Card class="p-4 space-y-1 gap-2">
                 <div class="font-bold text-gray-700 flex justify-between items-center">
                   <span>Beat {{ index + 1 }}</span>

--- a/src/renderer/pages/project/components/script_editor.vue
+++ b/src/renderer/pages/project/components/script_editor.vue
@@ -37,7 +37,7 @@
             leave-to-class="opacity-0 translate-y-2 scale-95"
             move-class="transition-all duration-300 ease-in-out"
           >
-            <div v-for="(beat, index) in safeBeats ?? []" :key="getBeatId(beat)" class="relative">
+            <div v-for="(beat, index) in safeBeats" :key="beat?.id || `beat-${index}`" class="relative">
               <Card class="p-4 space-y-1 gap-2">
                 <div class="font-bold text-gray-700 flex justify-between items-center">
                   <span>Beat {{ index + 1 }}</span>
@@ -252,17 +252,6 @@ const projectId = computed(() => route.params.id as string);
 
 const currentTab = ref<ScriptEditorTab>(props.scriptEditorActiveTab || SCRIPT_EDITOR_TABS.TEXT);
 const lastTab = ref<ScriptEditorTab>(props.scriptEditorActiveTab || SCRIPT_EDITOR_TABS.TEXT);
-
-// TransitionGroup 向け 一時的な BeatIDを管理
-const beatIdMap = new WeakMap();
-const getBeatId = (beat: MulmoBeat | undefined) => {
-  if (!beat) return `empty-beat-${Date.now()}-${Math.random()}`;
-  
-  if (!beatIdMap.has(beat)) {
-    beatIdMap.set(beat, `beat-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`);
-  }
-  return beatIdMap.get(beat);
-};
 
 const safeBeats = computed(() => {
   return props.mulmoValue?.beats ?? [];


### PR DESCRIPTION
- TransitionGroup animations 実装しました
- 一部アニメーションが不安定です。
   - 条件 - beat.id が付与されていない beat を動かす時。
     - 新規プロジェクト作成時
     - Create Script にて生成された直後
     - insert Beat をした beat を入れ替えるとき 
- タブを変更して、もう一度 TEXT/MEDIA タブに戻れば正しく動作します

== 以下、Claude からの Report / 西井確認済み ===
 問題: Beat（スライド）を並び替える際に、TransitionGroupのアニメーションが正しく動作しない場合があります。

  原因:
  - 新規作成されたBeatにはIDが付与されていない
  - TransitionGroupのkeyにbeat?.id ?? indexを使用しているため、IDがないBeatはindexをkeyとして使用
  - 並び替え時にindexが変わるため、Vueが要素の移動を正しく追跡できない

  試みた解決策:
  1. WeakMapを使用した一時IDの管理 → テキスト編集時にオブジェクトが再作成されるため断念
  2. テキストのハッシュ値をIDとして使用 → テキスト変更時にIDが変わるため断念
  3. インデックスベースの安定したID生成 → 並び替え時に結局indexが変わるため効果なし

  現在の状態:
  - Media / TEXT タブでIDが付与されるまでは、並び替えアニメーションが正しく動作しない
  - IDが付与された後は正常に動作

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added smooth animated transitions when adding, removing, or reordering beats in the Text and Media tabs of the script editor.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->