### PR TITLE
downloadImageFiles() after generate image

### DIFF
--- a/src/renderer/pages/project/project.vue
+++ b/src/renderer/pages/project/project.vue
@@ -590,6 +590,12 @@ watch(
     if (mulmoEvent && mulmoEvent.kind === "session" && mulmoEvent.sessionType === "video" && !mulmoEvent.inSession) {
       playVideo();
     }
+
+    // generate image
+    if (mulmoEvent && mulmoEvent.kind === "session" && mulmoEvent.sessionType === "image" && !mulmoEvent.inSession) {
+      await downloadImageFiles();
+    }
+
     // beats
     if (
       mulmoEvent &&


### PR DESCRIPTION
#235 の対応です

## 問題の概要
メディアタブでコンテンツ生成後に画像プレビューが表示されない問題が発生している。

## 根本原因の分析
現在のdownloadImageFiles実行タイミング

- プロジェクト読み込み時のみ（473行目）

 ## 問題が発生するシナリオ
- Generate Images完了後 → 画像ファイルは生成されるが、downloadImageFilesが呼ばれない

 - 個別beat画像生成は正常動作
    - 496-512行目で個別beat完了時は正しく更新される
    - 問題は一括処理完了時の更新不足

 ## 修正方針
 ファイル: /src/renderer/pages/project/project.vue修正箇所: 488-527行目のwatch関数内

 ## 修正後の動作フロー
1. ユーザーがGenerate Imagesボタンを押す
2. 一括画像生成が実行される
3. 生成完了時にsessionType === "image"のイベントが発生
4. downloadImageFiles()が実行される
5. 新しく生成された画像がメディアタブに表示される

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled automatic downloading of image files when an image session event ends.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->