### PR TITLE
update design 

### DIFF
--- a/src/renderer/i18n/en.ts
+++ b/src/renderer/i18n/en.ts
@@ -42,6 +42,9 @@ const lang = {
         title: "Slide Title",
         contents: "Slide Contents\nMarkdown bullets\n- one\n- two",
       },
+      markdown: {
+        contents: "Markdown Contents\n# Title\nWrite your content here...\n- Item 1\n- Item 2\n- Item 3",
+      },
     },
   },
   languages,

--- a/src/renderer/pages/project/components/script_editor/beat_editor.vue
+++ b/src/renderer/pages/project/components/script_editor/beat_editor.vue
@@ -63,6 +63,7 @@
           <template v-else-if="beat.image.type === 'markdown'">
             <Label class="block mb-1"> Markdown Text </Label>
             <Textarea
+              :placeholder="t('beat.form.markdown.contents')"
               :model-value="
                 Array.isArray(beat.image?.markdown) ? beat.image?.markdown.join('\n') : beat.image?.markdown
               "

--- a/src/renderer/pages/project/components/script_editor/beat_editor.vue
+++ b/src/renderer/pages/project/components/script_editor/beat_editor.vue
@@ -1,11 +1,14 @@
 <template>
   <div>
     <div class="flex items-center justify-between mb-2">
-      <h4 class="font-medium">Beat: {{ index + 1 }}</h4>
+      <div class="font-medium flex items-center gap-3">
+        <span class="text-base">Beat: {{ index + 1 }}</span>
+        <Badge variant="outline">{{ beat.speaker }}</Badge>
+      </div>
       <Badge variant="outline">{{ $t("beat.badge." + getBadge(beat)) }}</Badge>
     </div>
 
-    <p class="text-sm text-gray-600 mb-2">{{ beat.speaker }}: {{ beat.text }}</p>
+    <p class="text-sm text-gray-600 mb-2">{{ beat.text }}</p>
 
     <div class="grid grid-cols-2 gap-4">
       <!-- left: Edit area -->

--- a/src/renderer/pages/project/components/script_editor/beat_editor.vue
+++ b/src/renderer/pages/project/components/script_editor/beat_editor.vue
@@ -3,7 +3,7 @@
     <div class="flex items-center justify-between mb-2">
       <div class="font-medium flex items-center gap-3">
         <span class="text-base">Beat: {{ index + 1 }}</span>
-        <Badge variant="outline">{{ beat.speaker }}</Badge>
+        <Badge v-if="beat.speaker" variant="outline">{{ beat.speaker }}</Badge>
       </div>
       <Badge variant="outline">{{ $t("beat.badge." + getBadge(beat)) }}</Badge>
     </div>

--- a/src/shared/beat_data.ts
+++ b/src/shared/beat_data.ts
@@ -56,8 +56,8 @@ export const beatTemplate: { name: string; beat: MulmoBeat }[] = [
       image: {
         type: "textSlide",
         slide: {
-          title: "No Audio",
-          bullets: ["0.5 seconds"],
+          title: "",
+          bullets: [""],
         },
       },
     },


### PR DESCRIPTION
- beat の横に speaker を移動
<img width="293" height="100" alt="image" src="https://github.com/user-attachments/assets/c37786e0-4b4a-4e36-96da-110f73f6aec2" />
- script editor - markdown i18n 対応
- script editor - markdown に初期値が入っている関係で、place holder が表示されない → 初期値削除 しました。