### PR TITLE
Fix chart placeholder display and escape braces in i18n

### DIFF
--- a/src/renderer/i18n/en.ts
+++ b/src/renderer/i18n/en.ts
@@ -49,7 +49,7 @@ const lang = {
         contents: "Enter HTML prompt to generate custom slide content.",
       },
       chart: {
-        contents: "Enter chart data in JSON format\n" + "{\n}",
+        contents: "Enter chart data in JSON format\n{'{'}\n  \"type\": \"bar\",\n  \"data\": {'{'} ... {'}'}\n{'}'}",
       },
       mermaid: {
         contents: "Enter Mermaid diagram code.",

--- a/src/renderer/i18n/ja.ts
+++ b/src/renderer/i18n/ja.ts
@@ -49,7 +49,8 @@ const lang = {
         contents: "カスタムスライドコンテンツを生成するためのHTMLプロンプトを入力してください。",
       },
       chart: {
-        contents: "チャートデータをJSON形式で入力してください\n{'{'}\n  \"type\": \"bar\",\n  \"data\": {'{'} ... {'}'}\n{'}'}",
+        contents:
+          "チャートデータをJSON形式で入力してください\n{'{'}\n  \"type\": \"bar\",\n  \"data\": {'{'} ... {'}'}\n{'}'}",
       },
       mermaid: {
         contents: "Mermaidダイアグラムコードを入力してください。",

--- a/src/renderer/i18n/ja.ts
+++ b/src/renderer/i18n/ja.ts
@@ -49,7 +49,7 @@ const lang = {
         contents: "カスタムスライドコンテンツを生成するためのHTMLプロンプトを入力してください。",
       },
       chart: {
-        contents: "チャートデータをJSON形式で入力してください。",
+        contents: "チャートデータをJSON形式で入力してください\n{'{'}\n  \"type\": \"bar\",\n  \"data\": {'{'} ... {'}'}\n{'}'}",
       },
       mermaid: {
         contents: "Mermaidダイアグラムコードを入力してください。",

--- a/src/shared/beat_data.ts
+++ b/src/shared/beat_data.ts
@@ -81,7 +81,7 @@ export const beatTemplate: { name: string; beat: MulmoBeat }[] = [
       image: {
         type: "chart",
         title: "",
-        chartData: {},
+        chartData: undefined,
       },
     },
   },


### PR DESCRIPTION
### src/shared/beat_data.ts
- ChartのchartDataをundefinedに変更してplaceholderが正しく表示されるように修正

### src/renderer/i18n/en.ts / src/renderer/i18n/ja.ts
- i18nのプレースホルダーエラーを回避するため、JSONの例で使用する中括弧をエスケープ処理（{'{'} と  {'}'} を使用）

これにより、Chartフィールドで空の配列 {} が表示される問題が解決し、適切なplaceholderが表示されるようになりました。

### 懸念事項
- Insert 直後に「invalid_union: something broken.」 と表示される。
<img width="753" height="361" alt="image" src="https://github.com/user-attachments/assets/a1fcafe3-ade7-4ca1-9e43-b717d0ce25ed" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced placeholder and prompt for the "chart" input field, now showing a detailed JSON example in both English and Japanese.
* **Refactor**
  * Updated the default handling of chart data to improve how empty values are represented.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->