### PR TITLE
Add default

### DIFF
--- a/src/renderer/pages/project/components/script_editor/parameters/movie_params.vue
+++ b/src/renderer/pages/project/components/script_editor/parameters/movie_params.vue
@@ -104,11 +104,11 @@ const emit = defineEmits<{
 }>();
 
 const DEFAULT_VALUES: MovieParams = {
-  provider: undefined,
+  provider: provider2MovieAgent.replicate.agentName,
   model: "",
   transition: {
     type: undefined,
-    duration: 0,
+    duration: 0.3,
   },
 };
 


### PR DESCRIPTION
movie paramsにdefaultを追加しました
- provider: replicate
- duration: 0.3


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated default movie provider to use the agent name of the "replicate" provider.
  * Changed default movie transition duration to 0.3 seconds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->