### PR TITLE
add refecence image generator

### DIFF
--- a/src/main/mulmo/handler.ts
+++ b/src/main/mulmo/handler.ts
@@ -18,8 +18,10 @@ import {
   MulmoPresentationStyleMethods,
   setFfmpegPath,
   setFfprobePath,
+  generateReferenceImage,
+  getImageRefs,
 } from "mulmocast";
-import type { MulmoStudioContext } from "mulmocast";
+import type { MulmoStudioContext, MulmoImagePromptMedia } from "mulmocast";
 import type { TransactionLog } from "graphai";
 import path from "path";
 import fs from "fs";
@@ -166,6 +168,54 @@ export const mulmoGenerateAudio = async (projectId: string, index: number, webCo
       result: false,
       error,
     };
+  }
+};
+
+export const mulmoReferenceImages = async (projectId: string, webContents: WebContents) => {
+  const mulmoCallback = mulmoCallbackGenerator(projectId, webContents);
+  try {
+    addSessionProgressCallback(mulmoCallback);
+    const context = await getContext(projectId, true);
+    const images = await getImageRefs(context);
+    removeSessionProgressCallback(mulmoCallback);
+    return images;
+  } catch (error) {
+    removeSessionProgressCallback(mulmoCallback);
+    webContents.send("progress-update", {
+      projectId,
+      type: "error",
+      data: error,
+    });
+  }
+};
+export const mulmoReferenceImage = async (
+  projectId: string,
+  index: number,
+  key: string,
+  image: MulmoImagePromptMedia,
+  webContents: WebContents,
+) => {
+  const mulmoCallback = mulmoCallbackGenerator(projectId, webContents);
+  try {
+    addSessionProgressCallback(mulmoCallback);
+    const context = await getContext(projectId, true);
+    const returnImage = generateReferenceImage({
+      context,
+      index,
+      key,
+      image,
+      force: true,
+    });
+    console.log(returnImage);
+    removeSessionProgressCallback(mulmoCallback);
+    return returnImage;
+  } catch (error) {
+    removeSessionProgressCallback(mulmoCallback);
+    webContents.send("progress-update", {
+      projectId,
+      type: "error",
+      data: error,
+    });
   }
 };
 
@@ -423,6 +473,10 @@ export const mulmoHandler = async (method: string, webContents: WebContents, ...
         return await mulmoImageUpload(args[0], args[1], args[2], args[3]);
       case "mulmoImageFetchURL":
         return await mulmoImageFetchURL(args[0], args[1], args[2], webContents);
+      case "mulmoReferenceImage":
+        return await mulmoReferenceImage(args[0], args[1], args[2], args[3], webContents);
+      case "mulmoReferenceImages":
+        return await mulmoReferenceImages(args[0], webContents);
       default:
         throw new Error(`Unknown method: ${method}`);
     }

--- a/src/main/mulmo/handler.ts
+++ b/src/main/mulmo/handler.ts
@@ -153,7 +153,7 @@ export const mulmoGenerateAudio = async (projectId: string, index: number, webCo
   const mulmoCallback = mulmoCallbackGenerator(projectId, webContents);
   try {
     addSessionProgressCallback(mulmoCallback);
-    const context = await getContext(projectId, true);
+    const context = await getContext(projectId);
     // context.force = true;
     await generateBeatAudio(index, context, settings);
     removeSessionProgressCallback(mulmoCallback);
@@ -175,7 +175,7 @@ export const mulmoReferenceImages = async (projectId: string, webContents: WebCo
   const mulmoCallback = mulmoCallbackGenerator(projectId, webContents);
   try {
     addSessionProgressCallback(mulmoCallback);
-    const context = await getContext(projectId, true);
+    const context = await getContext(projectId);
     const images = await getImageRefs(context);
     removeSessionProgressCallback(mulmoCallback);
     return images;
@@ -186,6 +186,7 @@ export const mulmoReferenceImages = async (projectId: string, webContents: WebCo
       type: "error",
       data: error,
     });
+    return null;
   }
 };
 export const mulmoReferenceImage = async (
@@ -198,8 +199,8 @@ export const mulmoReferenceImage = async (
   const mulmoCallback = mulmoCallbackGenerator(projectId, webContents);
   try {
     addSessionProgressCallback(mulmoCallback);
-    const context = await getContext(projectId, true);
-    const returnImage = generateReferenceImage({
+    const context = await getContext(projectId);
+    const returnImage = await generateReferenceImage({
       context,
       index,
       key,
@@ -216,6 +217,7 @@ export const mulmoReferenceImage = async (
       type: "error",
       data: error,
     });
+    return null;
   }
 };
 

--- a/src/renderer/pages/project/project.vue
+++ b/src/renderer/pages/project/project.vue
@@ -292,6 +292,7 @@
                 </div>
               </CardContent>
             </Card>
+            <Button @click="reference">Reference</Button>
           </div>
         </div>
       </div>
@@ -641,4 +642,8 @@ watch(
   },
   { deep: true },
 );
+
+const reference = async () => {
+  window.electronAPI.mulmoHandler("mulmoReferenceImages", projectId.value);
+};
 </script>


### PR DESCRIPTION
reference imageをgenerateするhandlerを追加。デバックのために、projectページ下部にボタンを追加しています。

<img width="370" height="172" alt="スクリーンショット 2025-07-21 16 39 25" src="https://github.com/user-attachments/assets/0feb9a8c-e456-4aab-a57c-28d46f2d9e73" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Reference" button to the project page to fetch and display reference images related to the current project.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->