### PR TITLE
Change prompt inputs to fixed-height textareas

### DIFF
--- a/src/renderer/pages/project/components/script_editor/beat_editor.vue
+++ b/src/renderer/pages/project/components/script_editor/beat_editor.vue
@@ -151,19 +151,18 @@
           </template>
           <template v-else>
             <Label class="block mb-1"> Image Prompt: </Label>
-            <Input
+            <Textarea
               :placeholder="t('beat.form.imagePrompt.contents')"
               :model-value="beat.imagePrompt"
               @update:model-value="(value) => update('imagePrompt', String(value))"
-              type="text"
-              class="mb-2"
+              class="mb-2 h-20 overflow-y-auto"
             />
             <Label class="block mb-1"> Movie Prompt: </Label>
-            <Input
+            <Textarea
               :placeholder="t('beat.form.moviePrompt.contents')"
               :model-value="beat.moviePrompt"
               @update:model-value="(value) => update('moviePrompt', String(value))"
-              type="text"
+              class="mb-2 h-20 overflow-y-auto"
             />
           </template>
         </div>


### PR DESCRIPTION
script editor 
image prompt / movie prompt を input から text area への変更です

<img width="630" height="404" alt="image" src="https://github.com/user-attachments/assets/6745cd73-8f1d-4bbb-89b7-bedea7ba2e5c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the "Image Prompt" and "Movie Prompt" fields in the beat editor to use multi-line text areas for improved input experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->