### PR TITLE
delete none from movie provider

### DIFF
--- a/src/renderer/pages/project/script_editor/parameters/movie_params.vue
+++ b/src/renderer/pages/project/script_editor/parameters/movie_params.vue
@@ -12,7 +12,6 @@
             <SelectValue :placeholder="t('project.scriptEditor.movieParams.providerNone')" />
           </SelectTrigger>
           <SelectContent>
-            <SelectItem value="__undefined__">{{ t("project.scriptEditor.movieParams.providerNone") }}</SelectItem>
             <SelectItem v-for="provider in PROVIDERS" :key="provider.value" :value="provider.value">
               {{ provider.name }}
             </SelectItem>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the provider selection dropdown to remove the explicit "no provider" option, displaying only available providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->