### PR TITLE
Make speaker selectable

### DIFF
--- a/src/renderer/pages/project/script_editor.vue
+++ b/src/renderer/pages/project/script_editor.vue
@@ -47,6 +47,7 @@
                   :projectId="projectId"
                   :lang="mulmoValue.lang"
                   :mulmoMultiLingual="mulmoMultiLinguals?.[index]?.multiLingualTexts"
+                  :speakers="mulmoValue?.speechParams?.speakers ?? {}"
                   @update="update"
                   @saveMulmo="saveMulmo"
                 />

--- a/src/renderer/pages/project/script_editor/text_editor.vue
+++ b/src/renderer/pages/project/script_editor/text_editor.vue
@@ -5,12 +5,16 @@
   </div>
   <div>
     <Label>Speaker</Label>
-    <Input
-      :model-value="beat?.speaker"
-      @update:model-value="(value) => update(index, 'speaker', String(value))"
-      placeholder="e.g. Alice"
-      class="h-8"
-    />
+    <Select :model-value="beat?.speaker" @update:model-value="(value) => update(index, 'speaker', String(value))">
+      <SelectTrigger class="h-8">
+        <SelectValue placeholder="Select a speaker" />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectItem v-for="(_, name) in speakers" :key="name" :value="name">
+          {{ name }}
+        </SelectItem>
+      </SelectContent>
+    </Select>
   </div>
   <div>
     <Label>Text({{ t("languages." + lang) }})</Label>
@@ -47,7 +51,9 @@ import { useI18n } from "vue-i18n";
 import { type MulmoBeat, type MultiLingualTexts, languages } from "mulmocast/browser";
 
 import { Button, Label, Input, Badge } from "@/components/ui";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { getBadge } from "@/lib/beat_util.js";
+import type { MulmoPresentationStyle } from "mulmocast/browser";
 
 import { useMulmoEventStore, useMulmoGlobalStore } from "../../../store";
 import { notifyProgress } from "@/lib/notification";
@@ -64,6 +70,7 @@ interface Props {
   projectId: string;
   lang: string;
   mulmoMultiLingual: MultiLingualTexts;
+  speakers?: MulmoPresentationStyle["speechParams"]["speakers"];
 }
 const props = defineProps<Props>();
 


### PR DESCRIPTION
Speakerをspeech paramsのkey名で選択可能にしました

<img width="500" height="538" alt="CleanShot 2025-08-03 at 19 01 50@2x" src="https://github.com/user-attachments/assets/e9886b1f-db93-47fa-aef6-119ea162a5d0" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Speaker selection in the script editor is now done via a dropdown menu, allowing users to choose from predefined speaker names instead of entering free text.

* **Improvements**
  * The speaker input field now provides a clearer placeholder and restricts choices to available speakers, enhancing usability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->