### PR TITLE
feat: Add macOS code signing and notarization support

### DIFF
--- a/entitlements.plist
+++ b/entitlements.plist
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <!-- Electronに必要な最小限の権限 -->
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+</dict>
+</plist>

--- a/forge.config.ts
+++ b/forge.config.ts
@@ -12,6 +12,17 @@ const config: ForgeConfig = {
     asar: true,
     extraResource: [".vite/build/ffmpeg", "node_modules/mulmocast/assets", "node_modules/mulmocast/scripts"],
     icon: "./images/macoro.png",
+    osxSign: {
+      identity: process.env.CODESIGN_IDENTITY!,
+      hardenedRuntime: true,
+      entitlements: "entitlements.plist",
+      entitlementsInherit: "entitlements.plist",
+    } as any,
+    osxNotarize: {
+      appleId: process.env.AC_APPLE_ID!,
+      appleIdPassword: process.env.AC_PASSWORD!,
+      teamId: process.env.AC_TEAM_ID!,
+    },
   },
   rebuildConfig: {},
   makers: [new MakerSquirrel({}), new MakerZIP({}, ["darwin"]), new MakerRpm({}), new MakerDeb({})],

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "start": "NODE_ENV=development electron-forge start",
     "dev": "NODE_ENV=development vite --config vite.renderer.config.ts",
     "package": "electron-forge package",
-    "make": "electron-forge make",
+    "make": "bash -c 'set -a && source .env && set +a && electron-forge make'",
     "format": "prettier --write '{test/*,src/**/*,*}.{js,ts,vue,json}'",
     "format:check": "prettier --check '{src/**/*,*}.{js,ts,vue,json}'",
     "publish": "electron-forge publish",


### PR DESCRIPTION
## 概要

macOSアプリの署名と公証（notarization）に対応しました。これにより、ユーザーがGatekeeperによる警告なしでアプリを安全に実行できるようになります。

## 変更内容

-   **`entitlements.plist`**:
    -   Electronアプリの実行に必要な権限を定義します。
    -   `com.apple.security.cs.allow-jit`: V8 JavaScriptエンジンのJIT（Just-In-Time）コンパイラを有効化します。これがないと、ElectronアプリがmacOSのHardened Runtimeで正常に動作しません。
-   **`forge.config.ts`**:
    -   `osxSign` 設定を追加し、Developer ID証明書での署名を有効化します。
    -   `osxNotarize` 設定を追加し、Appleの公証サービスを利用します。
    -   認証情報は環境変数から読み込むように設定します。
-   **`package.json`**:
    -   `make` コマンド実行時に `.env` ファイルを自動で読み込むように設定しました。

## 必要な準備

1.  **Developer ID証明書**をキーチェーンにインストールします。
2.  **Apple Developer ID中間証明書**（G2）をキーチェーンにインストールします。詳細は[こちら GitHub Issues](https://github.com/receptron/mulmocast-app/issues/145#issuecomment-3148567169) 
3.  プロジェクトのルートに **`.env`** ファイルを作成し、以下の内容を設定します。
    -   `CODESIGN_IDENTITY`: 署名に使用する証明書の名前（例: "Developer ID Application: Your Name (XXXXXXXXXX)"）
    -   `AC_APPLE_ID`: Apple ID（メールアドレス）
    -   `AC_PASSWORD`: App-specific password（アプリ用のパスワード）
    -   `AC_TEAM_ID`: Team ID

## 使用方法

以下のコマンドを実行するだけで、署名から公証までが自動的に行われます。

```bash
yarn run make
```

## GitHub Actions対応（今後）

証明書を `.p12` 形式でエクスポートし、GitHub Secretsに登録することで、CI/CD環境でも同じ `yarn run make` コマンドで署名・公証が可能になります。

必要なSecretsは以下の通りです。

-   `APPLE_CERTIFICATE`: Base64エンコードされた `.p12` ファイル
-   `CSC_KEY_PASSWORD`: `.p12` ファイルのエクスポート時に設定したパスワード
-   その他、`.env`ファイルに設定した認証情報（`AC_APPLE_ID`, `AC_PASSWORD`, `AC_TEAM_ID`）
