### PR TITLE
feat(i18n): internationalize new_project_dialog.vue/text_editor.vue hardcoded text

### DIFF
--- a/src/renderer/i18n/en.ts
+++ b/src/renderer/i18n/en.ts
@@ -262,6 +262,10 @@ const lang = {
     },
   },
   project: {
+    newProject: {
+      title: "Create New Project",
+      placeholder: "Enter project title",
+    },
     header: {
       back: "Back",
       openProjectFolder: "Open Project Folder",

--- a/src/renderer/i18n/en.ts
+++ b/src/renderer/i18n/en.ts
@@ -16,8 +16,6 @@ const lang = {
 
       // Common labels and nouns
       title: "Title",
-      selectSpeaker: "Select a speaker",
-      examplePrompt: "e.g. What is AI?",
       description: "Description",
       key: "Key",
       image: "Image",
@@ -367,6 +365,7 @@ const lang = {
     badge: beatBadge,
     // Beat speaker settings
     speaker: {
+      selectSpeaker: "Select a speaker",
       placeholder: "{language} input: {speaker}'s voice content",
     },
     // Beat type structures (moved from beat.form.*)

--- a/src/renderer/i18n/en.ts
+++ b/src/renderer/i18n/en.ts
@@ -182,7 +182,6 @@ const lang = {
       mustBeNumber: "Must be a number",
       mustBeUrl: "Must be a valid URL",
     },
-
   },
   common: {
     drophere: "Drop file here",

--- a/src/renderer/i18n/en.ts
+++ b/src/renderer/i18n/en.ts
@@ -16,6 +16,8 @@ const lang = {
 
       // Common labels and nouns
       title: "Title",
+      selectSpeaker: "Select a speaker",
+      examplePrompt: "e.g. What is AI?",
       description: "Description",
       key: "Key",
       image: "Image",
@@ -180,6 +182,7 @@ const lang = {
       mustBeNumber: "Must be a number",
       mustBeUrl: "Must be a valid URL",
     },
+
   },
   common: {
     drophere: "Drop file here",
@@ -363,6 +366,10 @@ const lang = {
     videoPreview: "Video Preview",
     imagePreview: "Image Preview",
     badge: beatBadge,
+    // Beat speaker settings
+    speaker: {
+      placeholder: "{language} input: {speaker}'s voice content",
+    },
     // Beat type structures (moved from beat.form.*)
     image: {
       urlField: "URL",

--- a/src/renderer/i18n/ja.ts
+++ b/src/renderer/i18n/ja.ts
@@ -262,6 +262,10 @@ const lang = {
     },
   },
   project: {
+    newProject: {
+      title: "新規プロジェクト作成",
+      placeholder: "プロジェクトタイトルを入力",
+    },
     header: {
       back: "戻る",
       openProjectFolder: "プロジェクトのフォルダを開く",

--- a/src/renderer/i18n/ja.ts
+++ b/src/renderer/i18n/ja.ts
@@ -16,6 +16,8 @@ const lang = {
 
       // Common labels and nouns
       title: "タイトル",
+      selectSpeaker: "スピーカーを選択",
+      examplePrompt: "例：AIとは何ですか？",
       description: "説明",
       key: "キー",
       image: "画像",
@@ -180,6 +182,7 @@ const lang = {
       mustBeNumber: "数値である必要があります",
       mustBeUrl: "有効なURLである必要があります",
     },
+
   },
   common: {
     drophere: "画像をここにドロップ",
@@ -363,6 +366,10 @@ const lang = {
     videoPreview: "動画プレビュー",
     imagePreview: "画像プレビュー",
     badge: beatBadge,
+    // Beat speaker settings
+    speaker: {
+      placeholder: "{language}入力: {speaker}の音声生成内容",
+    },
     // Beat type structures (moved from beat.form.*)
     image: {
       urlField: "URL",

--- a/src/renderer/i18n/ja.ts
+++ b/src/renderer/i18n/ja.ts
@@ -16,8 +16,6 @@ const lang = {
 
       // Common labels and nouns
       title: "タイトル",
-      selectSpeaker: "スピーカーを選択",
-      examplePrompt: "例：AIとは何ですか？",
       description: "説明",
       key: "キー",
       image: "画像",
@@ -367,6 +365,7 @@ const lang = {
     badge: beatBadge,
     // Beat speaker settings
     speaker: {
+      selectSpeaker: "スピーカーを選択",
       placeholder: "{language}入力: {speaker}の音声生成内容",
     },
     // Beat type structures (moved from beat.form.*)

--- a/src/renderer/i18n/ja.ts
+++ b/src/renderer/i18n/ja.ts
@@ -182,7 +182,6 @@ const lang = {
       mustBeNumber: "数値である必要があります",
       mustBeUrl: "有効なURLである必要があります",
     },
-
   },
   common: {
     drophere: "画像をここにドロップ",

--- a/src/renderer/pages/dashboard/new_project_dialog.vue
+++ b/src/renderer/pages/dashboard/new_project_dialog.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="fixed inset-0 z-50 flex items-center justify-center bg-black/50" @click="handleBackdropClick">
     <div class="w-96 max-w-full rounded-lg bg-white p-6" @click.stop>
-      <h2 class="mb-4 text-xl font-semibold">{{ t('project.newProject.title') }}</h2>
+      <h2 class="mb-4 text-xl font-semibold">{{ t("project.newProject.title") }}</h2>
       <Input
         :model-value="props.modelValue"
         @update:model-value="(value) => emit('update:modelValue', String(value))"
@@ -10,9 +10,9 @@
         auto-focus
       />
       <div class="mt-4 flex justify-end space-x-3">
-        <Button @click="handleCancel" variant="ghost" :disabled="props.creating">{{ t('ui.actions.cancel') }}</Button>
+        <Button @click="handleCancel" variant="ghost" :disabled="props.creating">{{ t("ui.actions.cancel") }}</Button>
         <Button @click="handleCreate" :disabled="props.creating">
-          {{ props.creating ? t('ui.status.creating') : t('ui.actions.create') }}
+          {{ props.creating ? t("ui.status.creating") : t("ui.actions.create") }}
         </Button>
       </div>
     </div>

--- a/src/renderer/pages/dashboard/new_project_dialog.vue
+++ b/src/renderer/pages/dashboard/new_project_dialog.vue
@@ -1,18 +1,18 @@
 <template>
   <div class="fixed inset-0 z-50 flex items-center justify-center bg-black/50" @click="handleBackdropClick">
     <div class="w-96 max-w-full rounded-lg bg-white p-6" @click.stop>
-      <h2 class="mb-4 text-xl font-semibold">Create New Project</h2>
+      <h2 class="mb-4 text-xl font-semibold">{{ t('project.newProject.title') }}</h2>
       <Input
         :model-value="props.modelValue"
         @update:model-value="(value) => emit('update:modelValue', String(value))"
         type="text"
-        placeholder="Enter project title"
+        :placeholder="t('project.newProject.placeholder')"
         auto-focus
       />
       <div class="mt-4 flex justify-end space-x-3">
-        <Button @click="handleCancel" variant="ghost" :disabled="props.creating"> Cancel </Button>
+        <Button @click="handleCancel" variant="ghost" :disabled="props.creating">{{ t('ui.actions.cancel') }}</Button>
         <Button @click="handleCreate" :disabled="props.creating">
-          {{ props.creating ? "Creating..." : "Create" }}
+          {{ props.creating ? t('ui.status.creating') : t('ui.actions.create') }}
         </Button>
       </div>
     </div>
@@ -20,8 +20,11 @@
 </template>
 
 <script setup lang="ts">
+import { useI18n } from "vue-i18n";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
+
+const { t } = useI18n();
 
 const props = defineProps<{
   modelValue: string;

--- a/src/renderer/pages/project/script_editor/text_editor.vue
+++ b/src/renderer/pages/project/script_editor/text_editor.vue
@@ -7,7 +7,7 @@
     <Label>{{ t("ui.common.speaker") }}</Label>
     <Select :model-value="beat?.speaker" @update:model-value="(value) => update(index, 'speaker', String(value))">
       <SelectTrigger class="h-8">
-        <SelectValue :placeholder="t('ui.common.selectSpeaker')" />
+        <SelectValue :placeholder="t('beat.speaker.selectSpeaker')" />
       </SelectTrigger>
       <SelectContent>
         <SelectItem v-for="(_, name) in speakers" :key="name" :value="name">

--- a/src/renderer/pages/project/script_editor/text_editor.vue
+++ b/src/renderer/pages/project/script_editor/text_editor.vue
@@ -7,7 +7,7 @@
     <Label>{{ t("ui.common.speaker") }}</Label>
     <Select :model-value="beat?.speaker" @update:model-value="(value) => update(index, 'speaker', String(value))">
       <SelectTrigger class="h-8">
-        <SelectValue placeholder="Select a speaker" />
+        <SelectValue :placeholder="t('ui.common.selectSpeaker')" />
       </SelectTrigger>
       <SelectContent>
         <SelectItem v-for="(_, name) in speakers" :key="name" :value="name">
@@ -18,12 +18,16 @@
   </div>
   <div>
     <Label>{{ t("ui.tabs.text") }} ({{ t("languages." + lang) }})</Label>
-    <Input
+    <Textarea
       :model-value="beat.text"
       @update:model-value="(value) => update(index, 'text', String(value))"
       @blur="saveMulmo"
-      placeholder="e.g. What is AI?"
-      class="h-8"
+      :placeholder="t('beat.speaker.placeholder', { 
+        speaker: beat?.speaker || t('ui.common.speaker'), 
+        language: t('languages.' + lang) 
+      })"
+      rows="1"
+      class="resize-y min-h-8"
     />
   </div>
   <Button variant="outline" size="sm" @click="generateAudio(index)" class="w-fit">{{
@@ -54,7 +58,7 @@ import { computed, watch, ref } from "vue";
 import { useI18n } from "vue-i18n";
 import { type MulmoBeat, type MultiLingualTexts, languages, splitText } from "mulmocast/browser";
 
-import { Button, Label, Input, Badge } from "@/components/ui";
+import { Button, Label, Input, Badge, Textarea } from "@/components/ui";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { getBadge } from "@/lib/beat_util.js";
 import type { MulmoPresentationStyle } from "mulmocast/browser";

--- a/src/renderer/pages/project/script_editor/text_editor.vue
+++ b/src/renderer/pages/project/script_editor/text_editor.vue
@@ -22,12 +22,14 @@
       :model-value="beat.text"
       @update:model-value="(value) => update(index, 'text', String(value))"
       @blur="saveMulmo"
-      :placeholder="t('beat.speaker.placeholder', { 
-        speaker: beat?.speaker || t('ui.common.speaker'), 
-        language: t('languages.' + lang) 
-      })"
+      :placeholder="
+        t('beat.speaker.placeholder', {
+          speaker: beat?.speaker || t('ui.common.speaker'),
+          language: t('languages.' + lang),
+        })
+      "
       rows="1"
-      class="resize-y min-h-8"
+      class="min-h-8 resize-y"
     />
   </div>
   <Button variant="outline" size="sm" @click="generateAudio(index)" class="w-fit">{{


### PR DESCRIPTION
I18n 対応 - 以下２ファイルのハードコード対応

- new_project_dialog.vue
- text_editor.vue 

上記に加えて、以下の画像の場所 (Script Editor - Text tab)を input から text area へ変更

<img width="561" height="212" alt="image" src="https://github.com/user-attachments/assets/4c08bf5a-926e-41e3-996d-67057d47973d" />
