### PR TITLE
feat(i18n): add error messages and confirmation prompts for project actions

### DIFF
--- a/src/renderer/i18n/en.ts
+++ b/src/renderer/i18n/en.ts
@@ -261,6 +261,11 @@ const lang = {
       titleDesc: "Title (Z-A)",
     },
     empty: "No projects yet. Create your first project to get started!",
+    confirmDelete: 'Are you sure you want to delete "{title}"?',
+    errors: {
+      createProjectFailed: "Failed to create project. Please try again.",
+      deleteProjectFailed: "Failed to delete project. Please try again.",
+    },
   },
   project: {
     newProject: {

--- a/src/renderer/i18n/ja.ts
+++ b/src/renderer/i18n/ja.ts
@@ -261,6 +261,11 @@ const lang = {
       titleDesc: "タイトル（降順）",
     },
     empty: "まだプロジェクトはありません。最初のプロジェクトを作成して始めましょう！",
+    confirmDelete: "「{title}」を削除しますか？",
+    errors: {
+      createProjectFailed: "プロジェクトの作成に失敗しました。再試行してください。",
+      deleteProjectFailed: "プロジェクトの削除に失敗しました。再試行してください。",
+    },
   },
   project: {
     newProject: {

--- a/src/renderer/pages/dashboard.vue
+++ b/src/renderer/pages/dashboard.vue
@@ -197,7 +197,7 @@ const handleCreateProject = async () => {
     router.push(`/project/${project.metadata.id}`);
   } catch (error) {
     console.error("Failed to create project:", error);
-    alert("Failed to create project. Please try again.");
+    alert(t("dashboard.errors.createProjectFailed"));
   } finally {
     creating.value = false;
   }
@@ -210,13 +210,13 @@ const handleCancelDialog = () => {
 };
 
 const handleDeleteProject = async (project: Project) => {
-  if (confirm(`Are you sure you want to delete "${project?.script?.title}"`)) {
+  if (confirm(t("dashboard.confirmDelete", { title: project?.script?.title }))) {
     try {
       await projectApi.delete(project.metadata.id);
       await loadProjects();
     } catch (error) {
       console.error("Failed to delete project:", error);
-      alert("Failed to delete project. Please try again.");
+      alert(t("dashboard.errors.deleteProjectFailed"));
     }
   }
 };


### PR DESCRIPTION
ダッシュボードページの下記の i18n 対応の実施
- プロジェクトの削除確認メッセージ
- プロジェクト作成失敗メッセージ
- プロジェクトの削除失敗メッセージ