### PR TITLE
feat(i18n): add example message for user input placeholder in chat

### DIFF
--- a/src/renderer/i18n/en.ts
+++ b/src/renderer/i18n/en.ts
@@ -363,6 +363,7 @@ const lang = {
       copyScript: "Copy script",
       creating: "Creating...",
       createScript: "Create Script",
+      exampleMessage: "ex) Thank you very much! Please proceed with the creation.",
     },
   },
   beat: {

--- a/src/renderer/i18n/ja.ts
+++ b/src/renderer/i18n/ja.ts
@@ -363,6 +363,7 @@ const lang = {
       copyScript: "チャットへコピー",
       creating: "作成中...",
       createScript: "スクリプト作成",
+      exampleMessage: "例）ありがとうございます！作成を進めてください。",
     },
   },
   beat: {

--- a/src/renderer/pages/project/chat.vue
+++ b/src/renderer/pages/project/chat.vue
@@ -43,7 +43,7 @@
             autofocus
             v-model="userInput"
             :disabled="isRunning"
-            placeholder="ex) Thank you very much! Please proceed with the creation."
+            :placeholder="t('project.chat.exampleMessage')"
             class="field-sizing-content max-h-48 min-h-0 min-w-0 flex-1 rounded-lg border-2 border-none border-gray-200 bg-transparent bg-white px-3 py-2 text-sm outline-none focus-within:border-2 focus-within:border-blue-500"
             @keydown="handleKeydown"
           />


### PR DESCRIPTION
プロジェクト画面のチャットのプレースホルダーの i18n 対応

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The chat input placeholder now supports localization, displaying example messages in the user's selected language.

* **Style**
  * Replaced hardcoded placeholder text in the chat input with a translatable, localized string for improved internationalization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->