### PR TITLE
feat(i18n): add caption parameters translations

### DIFF
--- a/src/renderer/i18n/en.ts
+++ b/src/renderer/i18n/en.ts
@@ -51,6 +51,7 @@ const lang = {
       chat: "Chat",
       panel: "Panel",
       parameters: "Parameters",
+      example: "ex)",
 
       // Modal
       clickOutsideToClose: "Click outside to close",
@@ -460,6 +461,13 @@ const lang = {
       sizePreset: "Size Preset",
       width: "Width",
       height: "Height",
+    },
+    captionParams: {
+      title: "Caption Parameters",
+      language: "Language",
+      languageDescription: "Caption language",
+      styles: "Styles",
+      stylesDescription: "Enter CSS styles (one per line)",
     },
   },
 

--- a/src/renderer/i18n/ja.ts
+++ b/src/renderer/i18n/ja.ts
@@ -51,6 +51,7 @@ const lang = {
       chat: "チャット",
       panel: "パネル",
       parameters: "パラメータ",
+      example: "例)",
 
       // Modal
       clickOutsideToClose: "外側をクリックするとモーダルが閉じます",
@@ -460,6 +461,13 @@ const lang = {
       sizePreset: "サイズ設定",
       width: "幅",
       height: "高さ",
+    },
+    captionParams: {
+      title: "字幕設定",
+      language: "言語",
+      languageDescription: "字幕の言語",
+      styles: "スタイル",
+      stylesDescription: "CSSスタイルを入力してください(1行に1つずつ)",
     },
   },
 

--- a/src/renderer/pages/project/script_editor/parameters/caption_params.vue
+++ b/src/renderer/pages/project/script_editor/parameters/caption_params.vue
@@ -1,10 +1,10 @@
 <template>
   <Card class="p-4">
-    <h4 class="mb-3 font-medium">Caption Parameters</h4>
+    <h4 class="mb-3 font-medium">{{ t("parameters.captionParams.title") }}</h4>
     <div class="space-y-3">
       <div>
-        <Label>Language</Label>
-        <div class="mb-2 text-xs text-gray-500">Caption language</div>
+        <Label>{{ t("parameters.captionParams.language") }}</Label>
+        <div class="mb-2 text-xs text-gray-500">{{ t("parameters.captionParams.languageDescription") }}</div>
         <Select :model-value="props.captionParams?.lang || ''" @update:model-value="handleLangInput">
           <SelectTrigger>
             <SelectValue placeholder="None" />
@@ -18,11 +18,11 @@
         </Select>
       </div>
       <div>
-        <Label>Styles</Label>
-        <div class="mb-2 text-xs text-gray-500">Enter CSS styles (one per line)</div>
+        <Label>{{ t("parameters.captionParams.styles") }}</Label>
+        <div class="mb-2 text-xs text-gray-500">{{ t("parameters.captionParams.stylesDescription") }}</div>
         <Textarea
           v-model="styles"
-          placeholder="e.g. color: #FF6B6B;&#10;font-family: 'Arial Black', sans-serif;&#10;text-shadow: 2px 2px 4px rgba(0,0,0,0.5);"
+          :placeholder="`${t('ui.common.example')}\ncolor: #FF6B6B;\nfont-family: 'Arial Black', sans-serif;\ntext-shadow: 2px 2px 4px rgba(0,0,0,0.5);`"
           :class="['font-mono', { 'cursor-not-allowed bg-gray-100 text-gray-400': !props.captionParams?.lang }]"
           rows="6"
           :disabled="!props.captionParams?.lang"


### PR DESCRIPTION
captionParams の i18n 対応

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for localized UI text in both English and Japanese for caption parameter settings, including labels, descriptions, and examples.
  * Caption parameters UI now displays translated text and example styles based on the selected language.

* **Style**
  * Improved consistency of UI text by replacing hardcoded strings with dynamic translations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->