### PR TITLE
feat(i18n): add text slide parameters localization

### DIFF
--- a/src/renderer/i18n/en.ts
+++ b/src/renderer/i18n/en.ts
@@ -469,6 +469,11 @@ const lang = {
       styles: "Styles",
       stylesDescription: "Enter CSS styles (one per line)",
     },
+    textSlideParams: {
+      title: "Text Slide Parameters",
+      css: "CSS Styles",
+      cssDescription: "Enter CSS styles as a single string or multiple lines.",
+    },
   },
 
   modal: {

--- a/src/renderer/i18n/ja.ts
+++ b/src/renderer/i18n/ja.ts
@@ -469,6 +469,11 @@ const lang = {
       styles: "スタイル",
       stylesDescription: "CSSスタイルを入力してください(1行に1つずつ)",
     },
+    textSlideParams: {
+      title: "テキストスライド設定",
+      css: "CSSスタイル",
+      cssDescription: "CSSスタイルを単一文字列または複数行で入力してください",
+    },
   },
 
   modal: {

--- a/src/renderer/pages/project/script_editor/parameters/text_slide_params.vue
+++ b/src/renderer/pages/project/script_editor/parameters/text_slide_params.vue
@@ -1,14 +1,14 @@
 <template>
   <Card class="p-4">
-    <h4 class="mb-3 font-medium">Text Slide Parameters</h4>
+    <h4 class="mb-3 font-medium">{{ t("parameters.textSlideParams.title") }}</h4>
     <div class="space-y-3">
       <div>
-        <Label>CSS Styles</Label>
-        <div class="mb-2 text-xs text-gray-500">Enter CSS styles as a single string or multiple lines.</div>
+        <Label>{{ t("parameters.textSlideParams.css") }}</Label>
+        <div class="mb-2 text-xs text-gray-500">{{ t("parameters.textSlideParams.cssDescription") }}</div>
         <Textarea
           :model-value="cssStylesText"
           @update:model-value="handleCssStylesInput"
-          placeholder="e.g. font-size: 24px;&#10;color: #333;&#10;margin: 20px;"
+          :placeholder="`${t('ui.common.example')}\nfont-size: 24px;\ncolor: #333;\nmargin: 20px;`"
           class="font-mono"
           rows="6"
         />
@@ -20,9 +20,12 @@
 
 <script setup lang="ts">
 import { computed } from "vue";
+import { useI18n } from "vue-i18n";
 import { Card, Label, Textarea } from "@/components/ui";
 import MulmoError from "./mulmo_error.vue";
 import type { MulmoPresentationStyle } from "mulmocast/browser";
+
+const { t } = useI18n();
 
 const props = defineProps<{
   textSlideParams?: MulmoPresentationStyle["textSlideParams"];


### PR DESCRIPTION
textSlideParams の i18n 対応

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for localized text in both English and Japanese for text slide parameter labels and descriptions.
* **Style**
  * Updated the text slide parameters interface to display all user-facing text using translations based on the selected language.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->