### PR TITLE
feat(i18n): add localization for PDF

### DIFF
--- a/src/renderer/components/mulmo_viewer.vue
+++ b/src/renderer/components/mulmo_viewer.vue
@@ -31,7 +31,7 @@
         <FileText :size="64" class="mx-auto mb-4 text-gray-400" />
         <p class="mb-2 text-lg font-medium">{{ t("project.productTabs.pdf.title") }}</p>
         <p class="mb-4 text-sm text-gray-600">{{ t("project.productTabs.pdf.description") }}</p>
-        <div v-if="pages === 0">PDF not generated</div>
+        <div v-if="pages === 0">{{ t("project.productTabs.pdf.empty") }}</div>
         <div v-if="pages > 0">
           <div class="flex flex-wrap items-center justify-center gap-2">
             <Button variant="outline" @click="downloadPdf">

--- a/src/renderer/i18n/en.ts
+++ b/src/renderer/i18n/en.ts
@@ -341,6 +341,7 @@ const lang = {
         view: "View PDF",
         download: "Download PDF",
         details: "8 pages - A4 format - Size: 2.1 MB",
+        empty: "PDF not generated",
       },
       html: {
         title: "HTML Preview",

--- a/src/renderer/i18n/ja.ts
+++ b/src/renderer/i18n/ja.ts
@@ -335,11 +335,12 @@ const lang = {
         details: "再生時間: 12:34 - 解像度: 1920x1080 - サイズ: 145 MB",
       },
       pdf: {
-        title: "PDF Preview",
-        description: "PDF document display and download",
-        view: "View PDF",
-        download: "Download PDF",
-        details: "8 pages - A4 format - Size: 2.1 MB",
+        title: "PDFプレビュー",
+        description: "PDFファイルの表示とダウンロード",
+        view: "PDFを表示",
+        download: "PDFをダウンロード",
+        details: "8 ページ - A4 サイズ - サイズ: 2.1 MB",
+        empty: "PDF未生成",
       },
       html: {
         title: "HTML Preview",


### PR DESCRIPTION
productTabs の pdf の i18n 対応

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The message displayed when no PDF is available is now localized, providing translated text based on the selected language.

* **Documentation**
  * Updated English and Japanese language resources with new and improved translations for PDF-related messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->