### PR TITLE
feat: adjust language checkbox layout in settings

### DIFF
--- a/src/renderer/pages/settings.vue
+++ b/src/renderer/pages/settings.vue
@@ -112,8 +112,9 @@
               {{ t("settings.languages.translatedTitle") }}
             </div>
             <div v-for="(language, key) in languages" :key="key">
-              &ensp;{{ t("languages." + language) }}
+              &ensp;
               <Checkbox v-model="useLanguage[language]" />
+              {{ t("languages." + language) }}
             </div>
           </CardContent>
         </Card>


### PR DESCRIPTION
設定の翻訳先の言語にて、チェックボックスの位置を左に揃えたほうが見栄えが良いように思ったので対応
- 対応前
  - <img width="211" height="528" alt="スクリーンショット 2025-08-10 午後8 27 53" src="https://github.com/user-attachments/assets/c18ca498-4065-454b-8292-1233753b44dd" />

- 対応後
  - <img width="220" height="522" alt="スクリーンショット 2025-08-10 午後8 27 09" src="https://github.com/user-attachments/assets/ddc925c7-3ded-4021-8e96-e0f53fbf0517" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted the visual order of the language selection items in the settings page, displaying the checkbox before the language name in the "translated languages" section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->