### PR TITLE
Prevent script saving when opening project

### DIFF
--- a/src/renderer/pages/project.vue
+++ b/src/renderer/pages/project.vue
@@ -231,7 +231,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, watch, onMounted } from "vue";
+import { ref, computed, watch, onMounted, onUnmounted } from "vue";
 import { useDebounceFn } from "@vueuse/core";
 import { useRoute, useRouter } from "vue-router";
 import { useI18n } from "vue-i18n";
@@ -330,6 +330,10 @@ onMounted(async () => {
   }
 });
 
+onUnmounted(() => {
+  mulmoScriptHistoryStore.resetMulmoScript();
+});
+
 const handleUpdateScript = (script: MulmoScript) => {
   mulmoScriptHistoryStore.updateMulmoScript(script);
   isScriptViewerOpen.value = true;
@@ -367,8 +371,12 @@ const saveMulmoScript = useDebounceFn(saveMulmo, 1000);
 
 watch(
   () => mulmoScriptHistoryStore.currentMulmoScript,
-  () => {
-    // Be careful not to save a page just by opening it.
+  (newVal, oldVal) => {
+    // Skip saving when first watch
+    if (oldVal === null) {
+      return;
+    }
+    console.log("🙏saveMulmoScript");
     saveMulmoScript(mulmoScriptHistoryStore.currentMulmoScript);
   },
   { deep: true },
@@ -383,6 +391,7 @@ const mulmoError = computed<MulmoError>(() => {
 });
 
 const formatAndPushHistoryMulmoScript = () => {
+  console.log("🙏formatAndPushHistoryMulmoScript");
   const data = mulmoScriptSchema.safeParse(mulmoScriptHistoryStore.currentMulmoScript);
   if (data.success) {
     data.data.beats.map(setRandomBeatId);

--- a/src/renderer/pages/project/script_editor.vue
+++ b/src/renderer/pages/project/script_editor.vue
@@ -290,7 +290,10 @@ const safeBeats = computed(() => {
 });
 
 const handleUpdateScriptEditorActiveTab = (tab: ScriptEditorTab) => {
-  if (!props.isValidScriptData) {
+  if (
+    !props.isValidScriptData &&
+    ![SCRIPT_EDITOR_TABS.JSON, SCRIPT_EDITOR_TABS.YAML].includes(tab as "yaml" | "json")
+  ) {
     return;
   }
   lastTab.value = tab;

--- a/src/renderer/pages/project/script_editor.vue
+++ b/src/renderer/pages/project/script_editor.vue
@@ -1,5 +1,5 @@
 <template>
-  <Tabs class="w-full" v-model="currentTab">
+  <Tabs class="w-full" :model-value="currentTab" @update:model-value="handleUpdateScriptEditorActiveTab">
     <TabsList class="grid w-full grid-cols-6">
       <TabsTrigger :value="SCRIPT_EDITOR_TABS.TEXT">Text</TabsTrigger>
       <TabsTrigger :value="SCRIPT_EDITOR_TABS.YAML">YAML</TabsTrigger>
@@ -289,18 +289,14 @@ const safeBeats = computed(() => {
   return props.mulmoValue?.beats ?? [];
 });
 
-watch(currentTab, () => {
-  if (
-    !props.isValidScriptData &&
-    ![SCRIPT_EDITOR_TABS.JSON, SCRIPT_EDITOR_TABS.YAML].includes(currentTab.value as "yaml" | "json")
-  ) {
-    currentTab.value = lastTab.value;
-  } else {
-    lastTab.value = currentTab.value;
-    emit("formatAndPushHistoryMulmoScript");
-    emit("update:scriptEditorActiveTab", currentTab.value);
+const handleUpdateScriptEditorActiveTab = (tab: ScriptEditorTab) => {
+  if (!props.isValidScriptData) {
+    return;
   }
-});
+  lastTab.value = tab;
+  emit("formatAndPushHistoryMulmoScript");
+  emit("update:scriptEditorActiveTab", tab);
+};
 
 const mulmoMultiLinguals = ref([]);
 onMounted(async () => {

--- a/src/renderer/store/mulmo_script_history.ts
+++ b/src/renderer/store/mulmo_script_history.ts
@@ -19,6 +19,12 @@ export const useMulmoScriptHistoryStore = defineStore("mulmoScriptHistory", () =
     pushDataToHistory("init", data);
   };
 
+  const resetMulmoScript = () => {
+    currentMulmoScript.value = null;
+    index.value = 0;
+    histories.value = [];
+  };
+
   const updateMulmoScriptAndPushToHistory = (data: MulmoScript) => {
     currentMulmoScript.value = data;
     pushDataToHistory("push", data);
@@ -68,5 +74,6 @@ export const useMulmoScriptHistoryStore = defineStore("mulmoScriptHistory", () =
     undo,
     redoable,
     redo,
+    resetMulmoScript,
   };
 });


### PR DESCRIPTION
プロジェクトを開いただけで、プロジェクトが更新されてしまうバグを修正しました。

## Before

Projectを開いて、dashboardに戻ると順番が変わっている
（開いた際にscriptが更新され更新順のトップに並ぶため）


https://github.com/user-attachments/assets/b401794a-585a-4cce-ae5b-0ed01965454c



## After

Projectを開いて、dashboardに戻っても順番が変わらない


https://github.com/user-attachments/assets/dc2f8717-4d61-412d-883d-c8098d4afa72




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved tab switching in the script editor with explicit validation to prevent invalid transitions.
  * Script history is automatically reset when leaving the project page.

* **Bug Fixes**
  * Prevented tab changes when script data is invalid, preserving editor state and data integrity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->