### PR TITLE
fix: improve message display format in chat input

### DIFF
--- a/src/renderer/pages/project/chat.vue
+++ b/src/renderer/pages/project/chat.vue
@@ -33,9 +33,9 @@
     <div class="space-y-4">
       <!-- Message input field -->
       <div class="chat-input-wrapper">
-        <Label class="mb-2"
-          >{{ t("project.chat.enterMessage") }}
-          <span class="text-gray-400">({{ llmAgent }} {{ hasExa ? "with Search" : "" }})</span>
+        <Label class="mb-2">
+          {{ t("project.chat.enterMessage") }}
+          <span class="text-gray-400">{{ `(${llmAgent}${hasExa ? " with Search" : ""})` }}</span>
         </Label>
         <div class="chat-input-container flex items-center justify-between transition-colors duration-200">
           <Textarea
@@ -103,8 +103,6 @@ import * as agents from "@graphai/vanilla";
 import { openAIAgent, geminiAgent, anthropicAgent, groqAgent } from "@graphai/llm_agents";
 import exaToolsAgent from "../../agents/exa_agent";
 import toolsAgent from "../../agents/tools_agent";
-
-//import { toolsAgent } from "@graphai/tools_agent";
 
 // mulmo
 import { validateSchemaAgent } from "mulmocast/browser";


### PR DESCRIPTION
hasExa が false の場合であっても、llmAgent の後ろにスペースが入ってしまっていたため、対応

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the display of the label above the chat input field for improved clarity, now showing the agent name and search status together in a single line.

* **Chores**
  * Removed an unused commented-out import statement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->