### PR TITLE
feat(i18n): i18n support for custom in canvasSizeParams

### DIFF
--- a/src/renderer/i18n/en.ts
+++ b/src/renderer/i18n/en.ts
@@ -465,6 +465,7 @@ const lang = {
       sizePreset: "Size Preset",
       width: "Width",
       height: "Height",
+      custom: "Custom",
     },
     captionParams: {
       title: "Caption Parameters",

--- a/src/renderer/i18n/ja.ts
+++ b/src/renderer/i18n/ja.ts
@@ -465,6 +465,7 @@ const lang = {
       sizePreset: "サイズ設定",
       width: "幅",
       height: "高さ",
+      custom: "カスタム",
     },
     captionParams: {
       title: "字幕設定",

--- a/src/renderer/pages/project/script_editor/parameters/canvas_size_params.vue
+++ b/src/renderer/pages/project/script_editor/parameters/canvas_size_params.vue
@@ -12,7 +12,7 @@
             <SelectItem v-for="(size, key) in PRESET_CANVAS_SIZE" :key="key" :value="key">
               {{ size.width }}×{{ size.height }}
             </SelectItem>
-            <SelectItem value="custom">Custom</SelectItem>
+            <SelectItem value="custom">{{ t("parameters.canvasSizeParams.custom") }}</SelectItem>
           </SelectContent>
         </Select>
       </div>


### PR DESCRIPTION
canvasSizeParams の custom の i18n 対応

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - The Canvas Size presets now localize the “Custom” option in the parameters dropdown.
  - Added translations for English (“Custom”) and Japanese (“カスタム”), displayed automatically based on your selected app language.
  - Replaces previously hard-coded text, ensuring consistent localization across the UI.
  - No changes to behavior or selection logic—only the displayed label is updated for improved clarity, especially for non-English users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->