### PR TITLE
Fix #453

### DIFF
--- a/src/renderer/components/code_editor.vue
+++ b/src/renderer/components/code_editor.vue
@@ -103,14 +103,6 @@ onMounted(async () => {
         emit("update:modelValue", value);
       }
     });
-
-    editorInstance.value.onDidFocusEditorText(() => {
-      emit("focus");
-    });
-
-    editorInstance.value.onDidBlurEditorText(() => {
-      emit("blur");
-    });
   }
 });
 

--- a/src/renderer/pages/project/script_editor.vue
+++ b/src/renderer/pages/project/script_editor.vue
@@ -96,8 +96,6 @@
             language="yaml"
             :jsonSchema="mulmoJsonSchema"
             @update:modelValue="onYamlInput"
-            @focus="onFocus"
-            @blur="onBlur"
             minHeight="100%"
           />
         </div>
@@ -120,8 +118,6 @@
             language="json"
             :jsonSchema="mulmoJsonSchema"
             @update:modelValue="onJsonInput"
-            @focus="onFocus"
-            @blur="onBlur"
             minHeight="100%"
           />
         </div>
@@ -313,30 +309,15 @@ const syncTextFromInternal = () => {
   yamlText.value = YAML.stringify(internalValue.value);
 };
 
-const isEditing = ref(false);
-const onFocus = () => {
-  isEditing.value = true;
-};
-const onBlur = () => {
-  isEditing.value = false;
-};
 const hasScriptError = computed(() => {
   return Object.values(props.mulmoError?.script ?? {}).flat().length;
-});
-
-watch(isEditing, () => {
-  if (isEditing.value) {
-    syncTextFromInternal();
-  }
 });
 
 watch(
   () => props.mulmoValue,
   (newVal) => {
     internalValue.value = { ...newVal };
-    if (!isEditing.value) {
-      syncTextFromInternal();
-    }
+    syncTextFromInternal();
   },
   { deep: true, immediate: true },
 );


### PR DESCRIPTION
#453 の件の対応です。

- invalidなscriptでもYAML、JSONだけ遷移できる仕様を落とす
- focus時にinvalidなscriptを前の状態に戻す動きを削除 (← これが赤枠だけ残る原因）

この対応で、yaml or jsonモードでinvalidなscriptの状態の際は、シンプルにタブが変更できなくなります。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a safeguard that prevents switching between JSON and YAML tabs when script data is invalid, reducing errors.

- Bug Fixes
  - JSON/YAML editors now always reflect external changes immediately, preventing stale or out-of-sync content.
  - Removed unnecessary focus/blur handling from editors to reduce intermittent UI inconsistencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->