### PR TITLE
 feat: Add copy button to debug logs section

### DIFF
--- a/src/renderer/i18n/en.ts
+++ b/src/renderer/i18n/en.ts
@@ -241,6 +241,7 @@ const lang = {
       error: "Failed to save settings",
       createSuccess: "Script created successfully 🎉",
       copiedToClipboard: "Copied to clipboard",
+      copyFailed: "Failed to copy to clipboard",
     },
     languages: {
       title: "Language Settings",

--- a/src/renderer/i18n/en.ts
+++ b/src/renderer/i18n/en.ts
@@ -95,6 +95,7 @@ const lang = {
 
       // Chat actions
       clearChat: "Clear chat",
+      copy: "Copy",
       copyScript: "Copy script",
       createScript: "Create Script",
 
@@ -239,6 +240,7 @@ const lang = {
       success: "Settings saved",
       error: "Failed to save settings",
       createSuccess: "Script created successfully 🎉",
+      copiedToClipboard: "Copied to clipboard",
     },
     languages: {
       title: "Language Settings",

--- a/src/renderer/i18n/ja.ts
+++ b/src/renderer/i18n/ja.ts
@@ -240,6 +240,7 @@ const lang = {
       error: "設定の保存に失敗しました",
       createSuccess: "Script created successfully 🎉",
       copiedToClipboard: "クリップボードにコピーしました",
+      copyFailed: "クリップボードへのコピーに失敗しました",
     },
     languages: {
       title: "言語設定",

--- a/src/renderer/i18n/ja.ts
+++ b/src/renderer/i18n/ja.ts
@@ -95,6 +95,7 @@ const lang = {
 
       // Chat actions
       clearChat: "チャットリセット",
+      copy: "コピー",
       copyScript: "チャットへコピー",
       createScript: "スクリプト作成",
 
@@ -238,6 +239,7 @@ const lang = {
       success: "設定を保存しました",
       error: "設定の保存に失敗しました",
       createSuccess: "Script created successfully 🎉",
+      copiedToClipboard: "クリップボードにコピーしました",
     },
     languages: {
       title: "言語設定",

--- a/src/renderer/pages/project.vue
+++ b/src/renderer/pages/project.vue
@@ -188,7 +188,19 @@
               <CardContent class="space-y-4 p-4">
                 <!-- Debug Logs -->
                 <div class="rounded-lg bg-gray-50 p-4">
-                  <h3 class="mb-2 text-sm font-medium">{{ t("project.menu.debugLog") }}</h3>
+                  <div class="mb-2 flex items-center justify-between">
+                    <h3 class="text-sm font-medium">{{ t("project.menu.debugLog") }}</h3>
+                    <Button
+                      @click="copyDebugLogs"
+                      size="sm"
+                      variant="outline"
+                      :disabled="!debugLog || debugLog.length === 0"
+                      class="gap-2"
+                    >
+                      <Copy class="h-3 w-3" />
+                      {{ t("ui.actions.copy") }}
+                    </Button>
+                  </div>
                   <div class="h-40 overflow-y-auto rounded border bg-white p-2 font-mono text-xs" ref="logContainer">
                     <div v-for="(entry, i) in debugLog" :key="'debug-' + i" class="whitespace-pre-wrap">
                       {{ entry }}
@@ -237,6 +249,7 @@ import {
   PanelLeftOpen,
   PanelRightClose,
   PanelRightOpen,
+  Copy,
 } from "lucide-vue-next";
 import dayjs from "dayjs";
 import { mulmoScriptSchema, type MulmoScript } from "mulmocast/browser";
@@ -516,6 +529,20 @@ watch(
   },
   { deep: true },
 );
+
+// Copy debug logs to clipboard
+const copyDebugLogs = async () => {
+  if (!debugLog.value || debugLog.value.length === 0) return;
+  
+  const logsText = debugLog.value.join('\n');
+  
+  try {
+    await navigator.clipboard.writeText(logsText);
+    notifySuccess(t("settings.notifications.copiedToClipboard"));
+  } catch (error) {
+    console.error("Failed to copy debug logs:", error);
+  }
+};
 </script>
 
 <style scoped>

--- a/src/renderer/pages/project.vue
+++ b/src/renderer/pages/project.vue
@@ -272,7 +272,7 @@ import { getConcurrentTaskStatusMessageComponent } from "./project/concurrent_ta
 
 import { projectApi, type ProjectMetadata } from "@/lib/project_api";
 import { arrayPositionUp, arrayInsertAfter, arrayRemoveAt } from "@/lib/array";
-import { notifySuccess, notifyProgress } from "@/lib/notification";
+import { notifySuccess, notifyProgress, notifyError } from "@/lib/notification";
 import { setRandomBeatId } from "@/lib/beat_util.js";
 import { bufferToUrl } from "@/lib/utils";
 
@@ -534,13 +534,65 @@ watch(
 const copyDebugLogs = async () => {
   if (!debugLog.value || debugLog.value.length === 0) return;
 
-  const logsText = debugLog.value.join("\n");
+  // Build logsText by mapping entries to strings, pretty-printing non-strings
+  const logsText = debugLog.value
+    .map(item => {
+      if (typeof item === 'string') {
+        return item;
+      }
+      // Pretty-print non-string entries
+      return JSON.stringify(item, null, 2);
+    })
+    .join("\n");
 
-  try {
-    await navigator.clipboard.writeText(logsText);
+  // Try multiple clipboard methods in order of preference
+  let copySucceeded = false;
+
+  // Method 1: Try navigator.clipboard.writeText (modern browsers)
+  if (navigator.clipboard && navigator.clipboard.writeText) {
+    try {
+      await navigator.clipboard.writeText(logsText);
+      copySucceeded = true;
+    } catch (error) {
+      console.warn("navigator.clipboard.writeText failed:", error);
+    }
+  }
+
+  // Method 2: Try Electron clipboard API if available
+  if (!copySucceeded && window.electronAPI?.clipboard) {
+    try {
+      await window.electronAPI.clipboard.writeText(logsText);
+      copySucceeded = true;
+    } catch (error) {
+      console.warn("Electron clipboard API failed:", error);
+    }
+  }
+
+  // Method 3: Fallback to document.execCommand (older browsers, insecure contexts)
+  if (!copySucceeded) {
+    try {
+      const textarea = document.createElement("textarea");
+      textarea.value = logsText;
+      textarea.style.position = "fixed";
+      textarea.style.left = "-999999px";
+      textarea.style.top = "-999999px";
+      document.body.appendChild(textarea);
+      textarea.focus();
+      textarea.select();
+      
+      copySucceeded = document.execCommand("copy");
+      
+      document.body.removeChild(textarea);
+    } catch (error) {
+      console.error("document.execCommand('copy') failed:", error);
+    }
+  }
+
+  // Show appropriate feedback
+  if (copySucceeded) {
     notifySuccess(t("settings.notifications.copiedToClipboard"));
-  } catch (error) {
-    console.error("Failed to copy debug logs:", error);
+  } else {
+    notifyError(t("settings.notifications.copyFailed"));
   }
 };
 </script>

--- a/src/renderer/pages/project.vue
+++ b/src/renderer/pages/project.vue
@@ -533,9 +533,9 @@ watch(
 // Copy debug logs to clipboard
 const copyDebugLogs = async () => {
   if (!debugLog.value || debugLog.value.length === 0) return;
-  
-  const logsText = debugLog.value.join('\n');
-  
+
+  const logsText = debugLog.value.join("\n");
+
   try {
     await navigator.clipboard.writeText(logsText);
     notifySuccess(t("settings.notifications.copiedToClipboard"));

--- a/src/renderer/pages/project.vue
+++ b/src/renderer/pages/project.vue
@@ -536,8 +536,8 @@ const copyDebugLogs = async () => {
 
   // Build logsText by mapping entries to strings, pretty-printing non-strings
   const logsText = debugLog.value
-    .map(item => {
-      if (typeof item === 'string') {
+    .map((item) => {
+      if (typeof item === "string") {
         return item;
       }
       // Pretty-print non-string entries
@@ -579,9 +579,9 @@ const copyDebugLogs = async () => {
       document.body.appendChild(textarea);
       textarea.focus();
       textarea.select();
-      
+
       copySucceeded = document.execCommand("copy");
-      
+
       document.body.removeChild(textarea);
     } catch (error) {
       console.error("document.execCommand('copy') failed:", error);


### PR DESCRIPTION
  ## 概要
トラブルシューティングのために
Debug Logsセクションにコピーボタンを追加し、ログを簡単にクリップボードにコピーできるようにしました。

  ## 変更内容
  - Debug Logsセクションのヘッダーにコピーボタンを追加
  - クリップボードへのコピー機能を実装
  - ログが空の場合はボタンを無効化
  - コピー成功時の通知メッセージを表示

  ## 実装詳細
  - `lucide-vue-next`のCopyアイコンを使用
  - `navigator.clipboard.writeText` APIでクリップボードにコピー
  - i18nファイルに必要な翻訳を追加：
    - `ui.actions.copy`: "Copy" / "コピー"
    - `settings.notifications.copiedToClipboard`: "Copied to clipboard" / "クリップボードにコピーしました"

  ## スクリーンショット
  Debug Logsセクションの右上にコピーボタンが追加されました。
<img width="416" height="211" alt="image" src="https://github.com/user-attachments/assets/42eaf9ce-ae12-4c0e-a2fd-661c7612855d" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Copy button to the Debug Log to copy all log entries to the clipboard.
  * Button is disabled when no logs are available.
  * Shows a success notification after copying.
  * Shows an error notification if copying fails.
  * Non-text log entries are formatted for readability before copying.
  * English and Japanese translations added for the button and notifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->