### PR TITLE
Persist active tab

### DIFF
--- a/src/main/project_manager.ts
+++ b/src/main/project_manager.ts
@@ -5,7 +5,7 @@ import dayjs from "dayjs";
 import { MulmoScriptMethods, mulmoScriptSchema, type MulmoScript } from "mulmocast";
 
 import { Project, ProjectMetadata } from "../types";
-import { SCRIPT_EDITOR_TABS } from "../shared/constants";
+import { SCRIPT_EDITOR_TABS, MULMO_VIEWER_TABS } from "../shared/constants";
 import { initMulmoScript } from "../shared/beat_data";
 
 const PROJECTS_DIR = "projects";
@@ -120,6 +120,7 @@ export const createProject = async (title: string, lang: string): Promise<Projec
       chatMessages: [],
       useCache: false,
       scriptEditorActiveTab: SCRIPT_EDITOR_TABS.TEXT,
+      mulmoViewerActiveTab: MULMO_VIEWER_TABS.MOVIE,
     };
 
     const newScript = mulmoScriptSchema.strip().safeParse(initMulmoScript(title, lang));

--- a/src/renderer/components/mulmo_viewer/mulmo_viewer.vue
+++ b/src/renderer/components/mulmo_viewer/mulmo_viewer.vue
@@ -1,10 +1,10 @@
 <template>
-  <Tabs default-value="movie" class="max-h-[90vh] w-full">
+  <Tabs :model-value="currentTab" @update:model-value="handleUpdateTab" class="max-h-[90vh] w-full">
     <TabsList class="grid w-full grid-cols-4">
-      <TabsTrigger value="movie">{{ t("project.productTabs.tabs.movie") }}</TabsTrigger>
-      <TabsTrigger value="pdf">{{ t("project.productTabs.tabs.pdf") }}</TabsTrigger>
-      <TabsTrigger value="podcast">{{ t("project.productTabs.tabs.podcast") }}</TabsTrigger>
-      <TabsTrigger value="slide">{{ t("project.productTabs.tabs.slide") }}</TabsTrigger>
+      <TabsTrigger :value="MULMO_VIEWER_TABS.MOVIE">{{ t("project.productTabs.tabs.movie") }}</TabsTrigger>
+      <TabsTrigger :value="MULMO_VIEWER_TABS.PDF">{{ t("project.productTabs.tabs.pdf") }}</TabsTrigger>
+      <TabsTrigger :value="MULMO_VIEWER_TABS.PODCAST">{{ t("project.productTabs.tabs.podcast") }}</TabsTrigger>
+      <TabsTrigger :value="MULMO_VIEWER_TABS.SLIDE">{{ t("project.productTabs.tabs.slide") }}</TabsTrigger>
     </TabsList>
 
     <MovieTab :project-id="projectId" />
@@ -15,7 +15,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from "vue";
+import { computed, ref, watch } from "vue";
 import { useI18n } from "vue-i18n";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import MovieTab from "./tabs/movie_tab.vue";
@@ -23,13 +23,32 @@ import PdfTab from "./tabs/pdf_tab.vue";
 import PodcastTab from "./tabs/podcast_tab.vue";
 import SlideTab from "./tabs/slide_tab.vue";
 import type { Project } from "@/lib/project_api";
+import { MULMO_VIEWER_TABS, type MulmoViewerTab } from "../../../shared/constants";
 
 const { t } = useI18n();
 
 interface Props {
   project: Project;
+  mulmoViewerActiveTab?: MulmoViewerTab;
 }
 
 const props = defineProps<Props>();
+const emit = defineEmits(["update:mulmoViewerActiveTab"]);
+
 const projectId = computed(() => props.project?.metadata?.id || "");
+const currentTab = ref<MulmoViewerTab>(props.mulmoViewerActiveTab || MULMO_VIEWER_TABS.MOVIE);
+
+watch(
+  () => props.mulmoViewerActiveTab,
+  (newTab) => {
+    if (newTab && newTab !== currentTab.value) {
+      currentTab.value = newTab;
+    }
+  },
+);
+
+const handleUpdateTab = (tab: MulmoViewerTab) => {
+  currentTab.value = tab;
+  emit("update:mulmoViewerActiveTab", tab);
+};
 </script>

--- a/src/renderer/pages/dashboard.vue
+++ b/src/renderer/pages/dashboard.vue
@@ -103,9 +103,9 @@
           <DialogTitle>Mulmo Viewer</DialogTitle>
           <DialogDescription>{{ t("modal.clickOutsideToClose") }}</DialogDescription>
         </div>
-        <MulmoViewer 
-          v-if="selectedProject" 
-          :project="selectedProject" 
+        <MulmoViewer
+          v-if="selectedProject"
+          :project="selectedProject"
           :mulmoViewerActiveTab="selectedProject?.metadata?.mulmoViewerActiveTab"
           @update:mulmoViewerActiveTab="handleUpdateMulmoViewerActiveTab"
         />

--- a/src/renderer/pages/dashboard.vue
+++ b/src/renderer/pages/dashboard.vue
@@ -103,7 +103,12 @@
           <DialogTitle>Mulmo Viewer</DialogTitle>
           <DialogDescription>{{ t("modal.clickOutsideToClose") }}</DialogDescription>
         </div>
-        <MulmoViewer v-if="selectedProject" :project="selectedProject" />
+        <MulmoViewer 
+          v-if="selectedProject" 
+          :project="selectedProject" 
+          :mulmoViewerActiveTab="selectedProject?.metadata?.mulmoViewerActiveTab"
+          @update:mulmoViewerActiveTab="handleUpdateMulmoViewerActiveTab"
+        />
       </DialogContent>
     </Dialog>
   </Layout>
@@ -126,7 +131,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { Dialog, DialogContent, DialogTitle, DialogDescription } from "@/components/ui/dialog";
 
 import { projectApi, type Project } from "@/lib/project_api";
-import { SORT_BY, SORT_ORDER, VIEW_MODE } from "../../shared/constants";
+import { SORT_BY, SORT_ORDER, VIEW_MODE, type MulmoViewerTab } from "../../shared/constants";
 
 const router = useRouter();
 const { t } = useI18n();
@@ -225,6 +230,13 @@ const handleDeleteProject = async (project: Project) => {
 const handleViewProject = async (project: Project) => {
   selectedProject.value = project;
   isViewerOpen.value = true;
+};
+
+const handleUpdateMulmoViewerActiveTab = async (tab: MulmoViewerTab) => {
+  if (selectedProject.value) {
+    selectedProject.value.metadata.mulmoViewerActiveTab = tab;
+    await projectApi.saveProjectMetadata(selectedProject.value.metadata.id, selectedProject.value.metadata);
+  }
 };
 
 const updateSort = (value: string) => {

--- a/src/renderer/pages/project.vue
+++ b/src/renderer/pages/project.vue
@@ -179,9 +179,9 @@
                 </CardTitle>
               </CardHeader>
               <CardContent>
-                <MulmoViewer 
-                  v-if="project" 
-                  :project="project" 
+                <MulmoViewer
+                  v-if="project"
+                  :project="project"
                   :mulmoViewerActiveTab="projectMetadata?.mulmoViewerActiveTab"
                   @update:mulmoViewerActiveTab="handleUpdateMulmoViewerActiveTab"
                 />

--- a/src/renderer/pages/project.vue
+++ b/src/renderer/pages/project.vue
@@ -179,7 +179,12 @@
                 </CardTitle>
               </CardHeader>
               <CardContent>
-                <MulmoViewer v-if="project" :project="project" />
+                <MulmoViewer 
+                  v-if="project" 
+                  :project="project" 
+                  :mulmoViewerActiveTab="projectMetadata?.mulmoViewerActiveTab"
+                  @update:mulmoViewerActiveTab="handleUpdateMulmoViewerActiveTab"
+                />
               </CardContent>
             </Card>
 
@@ -289,7 +294,7 @@ import {
   gridLayoutClass,
 } from "./project/composable/style";
 import { ChatMessage, MulmoError } from "@/types";
-import { type ScriptEditorTab } from "../../shared/constants";
+import { type ScriptEditorTab, type MulmoViewerTab } from "../../shared/constants";
 
 import { zodError2MulmoError } from "../lib/error";
 
@@ -355,6 +360,11 @@ const handleUpdateChatMessages = (messages: ChatMessage[]) => {
 
 const handleUpdateScriptEditorActiveTab = (tab: ScriptEditorTab) => {
   projectMetadata.value.scriptEditorActiveTab = tab;
+  saveProjectMetadata(projectMetadata.value);
+};
+
+const handleUpdateMulmoViewerActiveTab = (tab: MulmoViewerTab) => {
+  projectMetadata.value.mulmoViewerActiveTab = tab;
   saveProjectMetadata(projectMetadata.value);
 };
 

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -257,6 +257,15 @@ export const SCRIPT_EDITOR_TABS = {
 
 export type ScriptEditorTab = (typeof SCRIPT_EDITOR_TABS)[keyof typeof SCRIPT_EDITOR_TABS];
 
+export const MULMO_VIEWER_TABS = {
+  MOVIE: "movie",
+  PDF: "pdf",
+  PODCAST: "podcast",
+  SLIDE: "slide",
+} as const;
+
+export type MulmoViewerTab = (typeof MULMO_VIEWER_TABS)[keyof typeof MULMO_VIEWER_TABS];
+
 export const LANGUAGES = [
   { id: "en" },
   { id: "es" },

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,5 +1,5 @@
 import type { MulmoScript, MulmoPresentationStyle } from "mulmocast";
-import type { ScriptEditorTab } from "../shared/constants";
+import type { ScriptEditorTab, MulmoViewerTab } from "../shared/constants";
 
 export type ChatMessage = {
   role: "user" | "assistant";
@@ -18,6 +18,7 @@ export type ProjectMetadata = {
   useCache?: boolean;
   presentationStyle?: MulmoPresentationStyle;
   scriptEditorActiveTab: ScriptEditorTab;
+  mulmoViewerActiveTab?: MulmoViewerTab;
 };
 export type Project = {
   metadata: ProjectMetadata;


### PR DESCRIPTION
Scritp Editor側と同様に、Mulmo ViewerのActive Tabを永続化しました。
DashboardおよびProjectで選択したTabを永続化します。

https://github.com/user-attachments/assets/4249a008-dac2-4fc9-a1a0-0e340ed52726



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Mulmo Viewer tabs are now controlled from the parent view, ensuring consistent state across the app.
  * The active tab selection is persisted per project, so your last chosen tab is remembered.
  * Dashboard and Project pages now display and sync the viewer’s active tab in real time.
  * Default active tab is set to Movie.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->