### PR TITLE
remove agent name

### DIFF
--- a/src/renderer/pages/project/chat/tools_message.vue
+++ b/src/renderer/pages/project/chat/tools_message.vue
@@ -5,10 +5,10 @@
     </div>
     <div class="flex-1">
       <div class="mb-2 rounded-lg bg-blue-100 px-2 py-1 text-xs font-semibold text-blue-700" v-if="data && isOpen">
-        {{ data?.agent }}({{ data?.func }}){{ data?.arg }}
+        {{ data?.func }}({{ data?.arg }})
       </div>
       <div class="mb-2 rounded-lg bg-blue-100 px-2 py-1 text-xs font-semibold text-blue-700" v-if="data && !isOpen">
-        {{ data?.agent }}({{ data?.func }}){}
+        {{ data?.func }}()
       </div>
       <div
         v-if="!isOpen"


### PR DESCRIPTION
#479 アイコンがあるので、Tool の Agent 名の表示は不要（"pushScript", "openUrl" のみで良い）