### PR TITLE
Fix TypeError when accessing undefined namedInputs in GraphAI callback

### DIFF
--- a/src/renderer/pages/project/chat.vue
+++ b/src/renderer/pages/project/chat.vue
@@ -281,8 +281,8 @@ const run = async () => {
           data: {
             isExecuting: state === "executing",
             agent: agentId,
-            arg: namedInputs.arguments,
-            func: namedInputs.func,
+            arg: namedInputs?.arguments,
+            func: namedInputs?.func,
           },
         };
       }


### PR DESCRIPTION
## 概要
AI アシススタントチャットにて、search が必要な時に発生。
GraphAIのコールバック処理において、`namedInputs`が`undefined`の場合に発生するTypeErrorを修正しました。

解決した時のキャプチャ
<img width="384" height="318" alt="image" src="https://github.com/user-attachments/assets/334c33d9-4047-4eb0-8cab-39176e6e926d" />


## 問題
`src/renderer/pages/project/chat.vue`の284-285行目で、`namedInputs`オブジェクトの`arguments`と`func`プロパティにアクセスする際、`namedInputs`が`undefined`の場合にTypeErrorが発生していました。

### エラーメッセージ
TypeError: Cannot read properties of undefined (reading 'arguments') at src/renderer/pages/project/chat.vue:144:34

## 修正内容
オプショナルチェイニング演算子（`?.`）を使用して、`namedInputs`が`undefined`の場合でも安全にプロパティにアクセスできるようにしました。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability of the Project Chat by gracefully handling missing input data during AI tool calls, preventing unexpected errors and potential freezes.
  * No changes to existing behavior when inputs are present; normal workflows remain unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->