### PR TITLE
add custom commands for cluade

### DIFF
--- a/.claude/commands/mcp-pw.md
+++ b/.claude/commands/mcp-pw.md
@@ -1,0 +1,16 @@
+---
+description: Connect to Electron app via MCP and take screenshot
+allowed-tools: mcp__electron-playwright__browser_tab_list, mcp__electron-playwright__browser_take_screenshot
+---
+
+Connect to the running Electron app at localhost:5173 via MCP and take a screenshot of the current state.
+
+1. Check available tabs using  
+   `mcp__electron-playwright__browser_tab_list`
+
+2. take a screenshot using  
+   `cp__electron-playwright__browser_take_screenshot`
+
+**IMPORTANT**: Do NOT use browser_navigate. The app already has an open page.
+
+3. MCP response is Japanese Language. 日本語で返信してください。


### PR DESCRIPTION
MCP 経由で接続する時にエラーが多いので、Claude Code の custom command を追加しました

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a guide for using MCP to connect to a running Electron app and capture screenshots.
  * Includes a step-by-step workflow: list available tabs, then take a screenshot, and avoid navigation since a page is already open.
  * Notes that responses are in Japanese and provides example prompts for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->