### PR TITLE
fix: 動画プロンプトと動画プレビューの縦方向の位置が一致していない。

### DIFF
--- a/src/renderer/pages/project/script_editor/beat_editor.vue
+++ b/src/renderer/pages/project/script_editor/beat_editor.vue
@@ -159,16 +159,6 @@
             />
           </template>
         </div>
-        <!-- movie edit -->
-        <div v-if="!beat.image && !beat.htmlPrompt">
-          <Label class="mb-1 block">{{ t("common.moviePrompt") }}: </Label>
-          <Textarea
-            :placeholder="t('beat.moviePrompt.placeholder')"
-            :model-value="beat.moviePrompt"
-            @update:model-value="(value) => update('moviePrompt', String(value))"
-            class="mb-2 h-20 overflow-y-auto"
-          />
-        </div>
       </div>
 
       <!-- right: image preview -->
@@ -184,6 +174,23 @@
           @openModal="openModal"
           @generateImage="generateImageOnlyImage"
         />
+      </div>
+
+      <!-- left: movie edit -->
+      <div class="flex flex-col gap-4" v-if="!beat.image && !beat.htmlPrompt">
+        <!-- movie edit -->
+        <div>
+          <Label class="mb-1 block">{{ t("common.moviePrompt") }}: </Label>
+          <Textarea
+            :placeholder="t('beat.moviePrompt.placeholder')"
+            :model-value="beat.moviePrompt"
+            @update:model-value="(value) => update('moviePrompt', String(value))"
+            class="mb-2 h-20 overflow-y-auto"
+          />
+        </div>
+      </div>
+      <!-- right: movie preview -->
+      <div class="flex flex-col gap-4" v-if="!beat.image && !beat.htmlPrompt">
         <BeatPreviewMovie
           :beat="beat"
           :index="index"
@@ -193,7 +200,6 @@
           :toggleTypeMode="toggleTypeMode"
           @openModal="openModal"
           @generateMovie="generateImageOnlyMovie"
-          v-if="!beat.image && !beat.htmlPrompt"
         />
       </div>
     </div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized the movie prompt editor to the left panel without changing data binding.
  * Unified visibility by wrapping the editor and movie preview in a single conditional container (shown only when no image or HTML prompt is set).
* **Style**
  * Adjusted layout for consistent alignment between the movie editor and preview.
  * Improved visual grouping of movie-related controls and preview for a cleaner editing experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->