### PR TITLE
 Fix E2E test for new project creation flow and improve error reporting

### DIFF
--- a/src/renderer/pages/project/project_header.vue
+++ b/src/renderer/pages/project/project_header.vue
@@ -10,7 +10,7 @@
       <div>
         <!-- Title -->
         <div class="group relative flex items-center">
-          <h1 v-if="!isEditingTitle" class="cursor-pointer text-2xl font-bold" @click="startEditingTitle">
+          <h1 v-if="!isEditingTitle" class="cursor-pointer text-2xl font-bold" @click="startEditingTitle" data-testid="project-title">
             {{ displayTitle }}
           </h1>
           <Input

--- a/test/automated_generation_e2e_test.ts
+++ b/test/automated_generation_e2e_test.ts
@@ -276,22 +276,23 @@ async function createProjectAndStartGeneration(projectsCreated: ProjectInfo[], p
 
   let projectTitle = "";
   let problematicBeatIndices: number[] = [];
+  let step = 1;
 
   try {
     // Navigate to dashboard
-    console.log("Navigating to dashboard...");
+    console.log(`${step}. Navigating to dashboard...`);
     await page.goto("http://localhost:5173/#/");
     await page.waitForLoadState("networkidle");
     console.log("✓ Dashboard loaded");
 
     // Click the create new button
-    console.log('\n2. Clicking "Create New" button...');
+    console.log(`\n${++step}. Clicking "Create New" button...`);
     await page.click('[data-testid="create-new-button"]');
     await page.waitForSelector('[data-testid="project-title"]');
     console.log("✓ Navigated to new project page");
 
     // Read JSON from local node_modules and analyze
-    console.log("\n8. Reading test JSON from local node_modules...");
+    console.log(`\n${++step}. Reading test JSON from local node_modules...`);
     let jsonContent: string;
 
     try {
@@ -348,7 +349,7 @@ async function createProjectAndStartGeneration(projectsCreated: ProjectInfo[], p
 
     // Generate project title (based on JSON title + timestamp) for later use
     projectTitle = `${baseTitle}_${dayjs().format("YYYYMMDD_HHmmss")}`;
-    console.log(`\n3. Project created with auto-generated title`);
+    console.log(`\n${++step}. Project created with auto-generated title`);
     console.log("✓ Project page loaded");
 
     // Store project info immediately after creation
@@ -362,7 +363,7 @@ async function createProjectAndStartGeneration(projectsCreated: ProjectInfo[], p
     console.log(`[DEBUG] Project added to list. Total: ${projectsCreated.length}`);
 
     // Navigate to JSON tab
-    console.log("\n6. Navigating to JSON tab...");
+    console.log(`\n${++step}. Navigating to JSON tab...`);
     await page.click('[data-testid="script-editor-tab-json"]');
     await new Promise((resolve) => setTimeout(resolve, CONFIG.TAB_SWITCH_DELAY));
 
@@ -378,12 +379,12 @@ async function createProjectAndStartGeneration(projectsCreated: ProjectInfo[], p
     }
 
     // Wait for Monaco Editor to be ready
-    console.log("\n7. Waiting for Monaco Editor...");
+    console.log(`\n${++step}. Waiting for Monaco Editor...`);
     await page.waitForSelector(".monaco-editor", { timeout: 15000 });
     console.log("✓ Monaco Editor loaded");
 
     // Clear existing content and input test JSON
-    console.log("\n9. Inputting test audio JSON...");
+    console.log(`\n${++step}. Inputting test audio JSON...`);
     // Focus on Monaco editor
     await page.click(".monaco-editor");
 
@@ -503,13 +504,13 @@ async function createProjectAndStartGeneration(projectsCreated: ProjectInfo[], p
     console.log("✓ JSON processing time completed");
 
     // Navigate to Media tab to delete problematic beats
-    console.log("\n7. Navigating to Media tab to clean up problematic assets...");
+    console.log(`\n${++step}. Navigating to Media tab to clean up problematic assets...`);
     await page.click('[data-testid="script-editor-tab-media"]');
     await new Promise((resolve) => setTimeout(resolve, CONFIG.TAB_SWITCH_DELAY));
     console.log("✓ Navigated to Media tab");
 
     // Delete beats with local_voice.mp3 using pre-identified indices
-    console.log("\n8. Deleting beats with local_voice.mp3...");
+    console.log(`\n${++step}. Deleting beats with local_voice.mp3...`);
 
     if (problematicBeatIndices.length > 0) {
       // Delete in reverse order to avoid index shifting issues
@@ -540,7 +541,7 @@ async function createProjectAndStartGeneration(projectsCreated: ProjectInfo[], p
     }
 
     // Find and click the generate button in output settings section
-    console.log("\n10. Looking for generate button in output settings section...");
+    console.log(`\n${++step}. Looking for generate button in output settings section...`);
 
     // Use data-testid to find the generate button
     const generateButton = await page.$('[data-testid="generate-contents-button"]');
@@ -551,7 +552,7 @@ async function createProjectAndStartGeneration(projectsCreated: ProjectInfo[], p
     await generateButton.click();
 
     // Start generation without waiting
-    console.log("\n10. Generation started, moving to next file...");
+    console.log(`\n${++step}. Generation started, moving to next file...`);
 
     // Wait a bit to ensure generation has started
     await new Promise((resolve) => setTimeout(resolve, 3000));

--- a/test/automated_generation_e2e_test.ts
+++ b/test/automated_generation_e2e_test.ts
@@ -287,8 +287,8 @@ async function createProjectAndStartGeneration(projectsCreated: ProjectInfo[], p
     // Click the create new button
     console.log('\n2. Clicking "Create New" button...');
     await page.click('[data-testid="create-new-button"]');
-    await page.waitForSelector('[data-testid="project-title-input"]');
-    console.log("✓ New project dialog opened");
+    await page.waitForSelector('[data-testid="project-title"]');
+    console.log("✓ Navigated to new project page");
 
     // Read JSON from local node_modules and analyze
     console.log("\n8. Reading test JSON from local node_modules...");
@@ -346,19 +346,10 @@ async function createProjectAndStartGeneration(projectsCreated: ProjectInfo[], p
       console.log("Could not read title from JSON, using default");
     }
 
-    // Enter project title (based on JSON title + timestamp)
+    // Generate project title (based on JSON title + timestamp) for later use
     projectTitle = `${baseTitle}_${dayjs().format("YYYYMMDD_HHmmss")}`;
-    console.log(`\n3. Entering project title: ${projectTitle}`);
-    await page.fill('[data-testid="project-title-input"]', projectTitle);
-    console.log("✓ Project title entered");
-
-    // Click the Create button
-    console.log('\n4. Clicking "Create" button...');
-    await page.click('[data-testid="create-button"]');
-
-    // Wait for project page to load
-    await page.waitForSelector(`h1:has-text("${projectTitle}")`);
-    console.log("✓ Project created and page loaded");
+    console.log(`\n3. Project created with auto-generated title`);
+    console.log("✓ Project page loaded");
 
     // Store project info immediately after creation
     const projectUrl = page.url();


### PR DESCRIPTION
## 概要
- 新しいプロジェクト作成フロー（モーダルダイアログなしで直接遷移）に対応するようE2Eテストを修正しました
- CI/CDへ適切にテスト失敗を報告するため、詳細な失敗追跡機能を追加
- ステップ番号をハードコードから自動採番へ変更

## 変更内容

  1. 新プロジェクト作成フローへの対応

  - プロジェクトヘッダーにdata-testid="project-title"を追加してテスト識別を可能に
  - モーダルダイアログではなくプロジェクトページへの遷移を待つように修正
  - 不要になったタイトル入力ステップを削除

  2. エラーレポート機能の強化

  - 各ファイルごとの詳細なテスト結果を追跡するProjectResultインターフェースを追加
  - 各工程（作成、生成、再生）での成功/失敗を記録
  - どのテストがどの工程で失敗したかを詳細に表示
  - テスト失敗時に確実にCI/CDへエラーを伝達（exit code 1）

  3. テスト保守性の改善

  - step変数による自動ステップ番号付けを導入
  - テストステップの追加/削除時の手動番号変更が不要に
  - テストログの一貫性と可読性が向上

  テスト出力例

  ===== Detailed Test Results =====
  Total test files: 4
  ✓ Success: 2
  ✗ Failed: 2

  === Failed Projects Details ===

  test_no_audio.json:
    Failed at: project_creation
    Created: ✗
    Generated: ✗
    Played: ✗
    Error: page.waitForSelector: Timeout 30000ms exceeded...

  影響範囲

  - これまでPASSと誤認識されていたテスト失敗が、CI/CDで正しく検出されるように
  - どのテストファイルがどの段階で失敗したかを開発者が迅速に特定可能
  - 自動ステップ番号により今後のテスト修正が容易に