### PR TITLE
ui: horizontal language selector layout and compact spacing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -282,6 +282,18 @@ When the Electron app is running in development mode (`yarn start`), Playwright 
 - **Performance Monitoring**: Track page load times and resource usage
 - **Live DOM Inspection**: Take snapshots and screenshots of the current application state
 
+**Usage for Development:**
+```bash
+# 1. Start Electron app with CDP enabled
+yarn start
+
+# 2. Use Claude Code with Playwright MCP to:
+# - Take screenshots: mcp__electron-playwright__browser_take_screenshot
+# - Capture console messages: mcp__electron-playwright__browser_console_messages
+# - Take DOM snapshots: mcp__electron-playwright__browser_snapshot
+# - Monitor network: mcp__electron-playwright__browser_network_requests
+```
+
 **Benefits for Development:**
 - Debug issues without modifying source code
 - Monitor application behavior in real-time

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -282,18 +282,6 @@ When the Electron app is running in development mode (`yarn start`), Playwright 
 - **Performance Monitoring**: Track page load times and resource usage
 - **Live DOM Inspection**: Take snapshots and screenshots of the current application state
 
-**Usage for Development:**
-```bash
-# 1. Start Electron app with CDP enabled
-yarn start
-
-# 2. Use Claude Code with Playwright MCP to:
-# - Take screenshots: mcp__electron-playwright__browser_take_screenshot
-# - Capture console messages: mcp__electron-playwright__browser_console_messages
-# - Take DOM snapshots: mcp__electron-playwright__browser_snapshot
-# - Monitor network: mcp__electron-playwright__browser_network_requests
-```
-
 **Benefits for Development:**
 - Debug issues without modifying source code
 - Monitor application behavior in real-time

--- a/src/renderer/pages/project.vue
+++ b/src/renderer/pages/project.vue
@@ -36,7 +36,7 @@
                   </Button>
                 </div>
               </CardHeader>
-              <CardContent class="flex flex-1 flex-col overflow-hidden" v-if="projectMetadata">
+              <CardContent class="flex flex-1 flex-col overflow-hidden -mt-6" v-if="projectMetadata">
                 <Chat
                   :mulmoScript="mulmoScriptHistoryStore.currentMulmoScript"
                   :messages="projectMetadata?.chatMessages"

--- a/src/renderer/pages/project.vue
+++ b/src/renderer/pages/project.vue
@@ -36,7 +36,7 @@
                   </Button>
                 </div>
               </CardHeader>
-              <CardContent class="flex flex-1 flex-col overflow-hidden -mt-6" v-if="projectMetadata">
+              <CardContent class="-mt-6 flex flex-1 flex-col overflow-hidden" v-if="projectMetadata">
                 <Chat
                   :mulmoScript="mulmoScriptHistoryStore.currentMulmoScript"
                   :messages="projectMetadata?.chatMessages"

--- a/src/renderer/pages/project/chat.vue
+++ b/src/renderer/pages/project/chat.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="flex h-full flex-col space-y-4">
+  <div class="flex h-full flex-col space-y-2">
     <SelectLanguage
       :mulmoScript="mulmoScript"
       @updateMulmoScript="(script) => emit('update:updateMulmoScript', script)"

--- a/src/renderer/pages/project/select_language.vue
+++ b/src/renderer/pages/project/select_language.vue
@@ -1,15 +1,17 @@
 <template>
-  <Languages :size="14" class="text-gray-500" />
-  <Select :model-value="currentLanguage" @update:model-value="handleLanguageChange">
-    <SelectTrigger class="h-6! w-30 border-gray-200 text-xs">
-      <SelectValue />
-    </SelectTrigger>
-    <SelectContent>
-      <SelectItem v-for="lang in LANGUAGES" :key="lang.id" :value="lang.id">
-        {{ t("languages." + lang.id) }}
-      </SelectItem>
-    </SelectContent>
-  </Select>
+  <div class="flex items-center gap-1">
+    <Languages :size="14" class="text-gray-500" />
+    <Select :model-value="currentLanguage" @update:model-value="handleLanguageChange">
+      <SelectTrigger class="h-6! w-30 border-gray-200 text-xs">
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectItem v-for="lang in LANGUAGES" :key="lang.id" :value="lang.id">
+          {{ t("languages." + lang.id) }}
+        </SelectItem>
+      </SelectContent>
+    </Select>
+  </div>
 </template>
 
 <script setup lang="ts">


### PR DESCRIPTION
1. select_language.vue:
    - 言語アイコンとドロップダウンを縦並びから横並び（flexbox）に変更
    - flex items-center gap-1で水平レイアウト実現
  2. chat.vue:
    -チャット要素間の垂直スペースを縮小（space-y-4 → space-y-2）
  3. project.vue:
    - CardContentに負のマージン-mt-6を追加してヘッダーとコンテンツ間のスペースを縮小
 
<img width="1008" height="860" alt="CleanShot 2025-08-17 at 16 04 20@2x" src="https://github.com/user-attachments/assets/36fd6591-e269-4f88-bbb1-9e695727b9cc" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Adjusted top margin in the left AI Chat column for improved visual alignment.
  * Reduced vertical spacing in the chat view for a more compact message stack.
  * Aligned the language selector and its control horizontally with consistent gaps for a cleaner, space-efficient layout.
  * No changes to application logic or public APIs; updates are purely presentational.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->