### PR TITLE
add no-raw-text rule

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -144,6 +144,12 @@ export default [
           math: "always",
         },
       ],
+      "@intlify/vue-i18n/no-raw-text": [
+        "warn",
+        {
+          ignorePattern: "[\\-():<>/]", 
+        },
+      ],
       ...sonarjsRules,
     },
     settings: {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - Added a Vue template linting rule that warns on raw text in templates.
  - Configured to ignore common punctuation and symbols to minimize noise.
  - Applies to linting during development and CI; no runtime behavior or UI is affected.
  - No other lint rules or settings were modified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->