### PR TITLE
Add bgm player

### DIFF
--- a/src/main/mulmo/handler.ts
+++ b/src/main/mulmo/handler.ts
@@ -37,7 +37,7 @@ import {
 } from "./handler_contents";
 import { mulmoImageFetchURL, mulmoReferenceImageFetchURL } from "./handler_image_fetch";
 import { mulmoReferenceImageUpload, mulmoImageUpload } from "./handler_image_upload";
-import { mulmoAudioBgmUpload } from "./handler_audio_upload";
+import { mulmoAudioBgmUpload, mulmoAudioBgmGet } from "./handler_audio_upload";
 import { graphaiPuppeteerAgent } from "./handler_graphai";
 import { mulmoCallbackGenerator, getContext } from "./handler_common";
 
@@ -193,6 +193,8 @@ export const mulmoHandler = async (method: string, webContents: WebContents, ...
         return await mulmoReferenceImageFetchURL(args[0], args[1], args[2], webContents);
       case "mulmoAudioBgmUpload":
         return await mulmoAudioBgmUpload(args[0], args[1], args[2]);
+      case "mulmoAudioBgmGet":
+        return await mulmoAudioBgmGet(args[0], args[1]);
       case "mulmoReferenceImage":
         return await mulmoReferenceImage(args[0], args[1], args[2], args[3], webContents);
       case "mulmoReferenceImages":

--- a/src/main/mulmo/handler_audio_upload.ts
+++ b/src/main/mulmo/handler_audio_upload.ts
@@ -14,3 +14,17 @@ export const mulmoAudioBgmUpload = async (projectId: string, filename: string, b
 
   return path.join(dirPath, filename);
 };
+
+export const mulmoAudioBgmGet = async (projectId: string, bgmPath: string) => {
+  const projectPath = getProjectPath(projectId);
+
+  const cleanPath = bgmPath.replace(/^\.\//, "");
+  const filePath = path.resolve(projectPath, cleanPath);
+
+  if (!fs.existsSync(filePath)) {
+    throw new Error(`BGM file not found: ${filePath}`);
+  }
+
+  const buffer = fs.readFileSync(filePath);
+  return buffer;
+};


### PR DESCRIPTION
#553

BGMの視聴機能を追加しました

## 通常

<img width="744" height="161" alt="image" src="https://github.com/user-attachments/assets/88bd8d4b-2068-4fd6-960d-944f888a6052" />

## Custom

<img width="749" height="247" alt="image" src="https://github.com/user-attachments/assets/50ea318e-9f45-47ca-890f-2695b7aae224" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an in-app audio player in Script Editor > Audio parameters to preview selected BGM.
  * Supports previewing BGMs from project files and external URLs.
  * Enables immediate preview of newly uploaded custom audio.

* **Improvements**
  * More reliable initialization and updates when changing BGM sources.
  * Automatically loads and displays the current BGM for quick playback.

* **Bug Fixes**
  * Cleans up temporary audio URLs on change/unmount to prevent memory leaks and stale playback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->