### PR TITLE
feat: position modal dialog at top and add height constraints

### DIFF
--- a/src/renderer/components/ui/dialog/DialogContent.vue
+++ b/src/renderer/components/ui/dialog/DialogContent.vue
@@ -29,7 +29,7 @@ const forwarded = useForwardPropsEmits(delegatedProps, emits);
       v-bind="forwarded"
       :class="
         cn(
-          'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-8 left-[50%] z-50 grid w-full max-w-2xl max-h-[calc(100vh-4rem)] translate-x-[-50%] gap-4 overflow-y-auto rounded-lg border p-6 shadow-lg duration-200',
+          'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-8 left-[50%] z-50 grid max-h-[calc(100vh-4rem)] w-full max-w-2xl translate-x-[-50%] gap-4 overflow-y-auto rounded-lg border p-6 shadow-lg duration-200',
           props.class,
         )
       "


### PR DESCRIPTION
モーダル内のタブを変更するたびに、タブの位置が変わるため、モーダルダイアログの表示位置を画面中央から画面上端（top: 32px）に変更しました。

合わせて以下の変更を加えました。

- 最大高さを calc(100vh - 4rem) に制限し、画面からはみ出さないように調整
- コンテンツが最大高さを超える場合は縦スクロール（overflow-y-auto）を有効化

<img width="1345" height="1015" alt="image" src="https://github.com/user-attachments/assets/bbd15be1-88f6-4386-ab0d-1c86f6efbc09" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated dialog positioning from centered to a top-aligned layout, improving visual consistency and reducing obstructive overlays.
  * Maintained existing animations, width constraints, padding, border, and shadow with minor ordering adjustments.

* **Bug Fixes**
  * Prevents dialog content from overflowing the viewport by capping height relative to the screen and enabling vertical scrolling.
  * Improves usability on smaller screens and with lengthy content by keeping dialogs accessible and readable without clipping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->