### PR TITLE
feat: refactor modal positioning to individual modal components

### DIFF
--- a/src/renderer/components/setting_modal.vue
+++ b/src/renderer/components/setting_modal.vue
@@ -1,7 +1,7 @@
 <template>
   <Dialog :open="globalStore.isOpenSettingModal" @update:open="globalStore.toggleSettingModal">
     <DialogOverlay class="bg-black/10" @click="globalStore.toggleSettingModal" />
-    <DialogContent class="h-[80%] w-[80%] max-w-3xl overflow-y-auto rounded-lg border-0 bg-white p-6 shadow-lg">
+    <DialogContent class="h-[90%] w-[80%] max-w-3xl overflow-y-auto rounded-lg border-0 bg-white p-6 shadow-lg">
       <div class="sr-only">
         <DialogTitle>{{ t("viewer.mediaPreview.modal.dialogTitle") }}</DialogTitle>
         <DialogDescription>{{ t("viewer.mediaPreview.modal.dialogDescription") }}</DialogDescription>

--- a/src/renderer/components/ui/dialog/DialogContent.vue
+++ b/src/renderer/components/ui/dialog/DialogContent.vue
@@ -29,7 +29,7 @@ const forwarded = useForwardPropsEmits(delegatedProps, emits);
       v-bind="forwarded"
       :class="
         cn(
-          'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-8 left-[50%] z-50 grid max-h-[calc(100vh-4rem)] w-full max-w-2xl translate-x-[-50%] gap-4 overflow-y-auto rounded-lg border p-6 shadow-lg duration-200',
+          'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-2xl translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200',
           props.class,
         )
       "

--- a/src/renderer/components/viewer_modal.vue
+++ b/src/renderer/components/viewer_modal.vue
@@ -1,6 +1,6 @@
 <template>
   <Dialog :open="!!globalStore.mulmoViewerProjectId" @update:open="globalStore.setMulmoViewerProjectId(null)">
-    <DialogContent class="max-h-[90vh] max-w-3xl">
+    <DialogContent class="!top-8 max-h-[90vh] max-w-3xl !translate-y-0">
       <div class="sr-only">
         <DialogTitle>{{ t("viewer.mulmo.modal.dialogTitle") }}</DialogTitle>
         <DialogDescription>{{ t("viewer.mulmo.modal.dialogDescription") }}</DialogDescription>


### PR DESCRIPTION
#614 の変更だと、image / movie の表示位置にも影響があったため、モーダルダイアログの位置制御を個別で実装しました。

### 変更内容
  - DialogContent.vue を元の中央配置に戻し、デフォルトの動作を維持
  - viewer_modal.vue に上端配置（!top-8 !translate-y-0）を個別に適用
  - setting_modal.vue の高さを80%から90%に拡張し、コンテンツ表示領域を改善

###  DialogContent のデフォルト動作
  - 配置: top-[50%] left-[50%] translate-x-[-50%] translate-y-[-50%]（画面中央）
  - サイズ: w-full max-w-2xl（全幅、最大幅2xl）
  - その他: fixed z-50 grid gap-4 rounded-lg border p-6 shadow-lg

### 各モーダルの動作
  1. 設定モーダル (setting_modal.vue)
  - 配置: 画面中央（DialogContentのデフォルト動作）
  - サイズ: 高さ90%、幅80%、最大幅3xl
  - スクロール: 縦スクロール対応（overflow-y-auto）
  - 用途: アプリケーション設定画面

  2. ビューアーモーダル (viewer_modal.vue)
  - 配置: 画面上端（!top-8 !translate-y-0で上書き）
  - サイズ: 最大高さ90vh、最大幅3xl
  - スクロール: DialogContentのデフォルト動作
  - 用途: プロジェクトプレビュー、スライドショー表示

  3. メディアモーダル (media_modal.vue)
  - 配置: 画面中央（DialogContentのデフォルト動作）
  - サイズ: 最大幅3xl、透明背景
  - スクロール: なし（画像・動画の直接表示）
  - 用途: 画像・動画ファイルのフルサイズプレビュー

### 技術的な改善点
  - !important修飾子により、DialogContentの基本スタイルを確実に上書き
  - デフォルト動作（中央配置）を維持しつつ、必要な箇所のみカスタマイズ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Increased Settings modal height to 90% for better content visibility.
  * Dialogs are now vertically centered on screen; removed max-height and internal vertical scrolling to allow fuller content display while keeping existing width constraints.
  * Adjusted Viewer modal positioning to use a top offset and no vertical translation for a more consistent layout, retaining 90vh max height and max width.
  * Overall improves visual consistency and readability across modals without changing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->