### PR TITLE
fix #640

### DIFF
--- a/src/renderer/pages/project.vue
+++ b/src/renderer/pages/project.vue
@@ -383,8 +383,9 @@ const handleUpdateChatMessages = (messages: ChatMessage[]) => {
   saveProjectMetadataDebounced();
 };
 
-const handleUpdateScriptEditorActiveTab = (tab: ScriptEditorTab) => {
+const handleUpdateScriptEditorActiveTab = async (tab: ScriptEditorTab) => {
   projectMetadata.value.scriptEditorActiveTab = tab;
+  await projectApi.saveProjectScript(projectId.value, mulmoScriptHistoryStore.currentMulmoScript);
   saveProjectMetadata({ updateTimestamp: false });
 };
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Script editor now reliably saves the current Mulmo script before switching tabs, preventing potential data loss.
  * Improved stability when changing the active tab in the project script editor, ensuring edits are preserved during quick tab changes.
  * More consistent behavior when updating project details after tab switches, resulting in a smoother editing experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->