### PR TITLE
auto play

### DIFF
--- a/src/renderer/components/mulmo_viewer/tabs/slide_tab.vue
+++ b/src/renderer/components/mulmo_viewer/tabs/slide_tab.vue
@@ -2,6 +2,10 @@
   <TabsContent value="slide" class="mt-4 max-h-[calc(90vh-7rem)] overflow-y-auto">
     <div class="border-border bg-muted/50 rounded-lg border p-8 text-center">
       <div class="mb-2 flex items-center justify-center gap-2">
+        <label>
+          <Checkbox v-model="autoPlay" />
+          {{ t("project.productTabs.slide.autoPlay") }}
+        </label>
         <SelectLanguage v-model="currentLanguage" />
         <Button variant="outline" @click="generateLocalize">{{ t("ui.actions.generate") }}</Button>
       </div>
@@ -61,7 +65,7 @@ import { useI18n } from "vue-i18n";
 import { FileImage } from "lucide-vue-next";
 import { sleep } from "graphai";
 
-import { Button } from "@/components/ui/button";
+import { Button, Checkbox } from "@/components/ui";
 import { TabsContent } from "@/components/ui/tabs";
 
 import { useImageFiles, useAudioFiles } from "@/pages/composable";
@@ -82,6 +86,7 @@ const emit = defineEmits(["updateMultiLingual"]);
 
 const currentPage = ref(0);
 const audioRef = ref();
+const autoPlay = ref(true);
 
 const currentLanguage = ref(props.project?.script?.lang ?? "en");
 
@@ -108,7 +113,7 @@ const decrease = () => {
 };
 
 const handleAudioEnded = async () => {
-  if (increase()) {
+  if (autoPlay.value && increase()) {
     await sleep(500);
     if (audioRef.value) {
       audioRef.value.play();

--- a/src/renderer/i18n/en.ts
+++ b/src/renderer/i18n/en.ts
@@ -408,6 +408,7 @@ const lang = {
         start: "Start Slideshow",
         export: "Export Images",
         details: "{current} / {pages} slides",
+        autoPlay: "Auto Play",
       },
     },
     chat: {

--- a/src/renderer/i18n/ja.ts
+++ b/src/renderer/i18n/ja.ts
@@ -407,6 +407,7 @@ const lang = {
         start: "スライドショーの開始",
         export: "スライドをエクスポート",
         details: "{current} / {pages} スライド",
+        autoPlay: "自動再生",
       },
     },
     chat: {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an Auto Play toggle to Slide Preview (in top controls), enabled by default.
  * Playback now advances to the next beat automatically only when Auto Play is on; with Auto Play off, progression stops at the end of audio.
  * Added English (“Auto Play”) and Japanese (“自動再生”) labels for the new control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->