### PR TITLE
add event callback on mulmo view

### DIFF
--- a/src/renderer/components/mulmo_viewer/tabs/slide_tab.vue
+++ b/src/renderer/components/mulmo_viewer/tabs/slide_tab.vue
@@ -192,7 +192,7 @@ watch(
         downloadAudioFile(index, mulmoEvent.id);
       }
       if (mulmoEvent.sessionType === "multiLingual") {
-        updateMultiLingual();
+        emit("updateMultiLingual");
       }
     }
     console.log(mulmoEvent);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Slide tab now auto-downloads image and audio assets in real time from project events (sessions, beat generation, beat updates).
  * Per-file (per-beat) download handlers introduced so only required assets are fetched, improving load times and multi-language responsiveness.
  * Existing language switching and navigation preserved while keeping slide content synchronized with live project events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->