### PR TITLE
Fix slide  tab

### DIFF
--- a/src/renderer/components/mulmo_viewer/tabs/slide_tab.vue
+++ b/src/renderer/components/mulmo_viewer/tabs/slide_tab.vue
@@ -17,7 +17,7 @@
       <div v-else>
         <div class="flex w-full items-center justify-between">
           <Button @click="decrease" variant="outline">{{ t("ui.common.decrease") }}</Button>
-          <div class="flex flex-1 flex-col justify-center">
+          <div class="flex min-w-0 flex-1 flex-col justify-center">
             <video
               v-if="lipSyncFiles?.[currentBeat?.id]"
               :src="lipSyncFiles?.[currentBeat?.id]"

--- a/src/renderer/components/mulmo_viewer/tabs/slide_tab.vue
+++ b/src/renderer/components/mulmo_viewer/tabs/slide_tab.vue
@@ -16,7 +16,14 @@
       </div>
       <div v-else>
         <div class="flex w-full items-center justify-between">
-          <Button @click="decrease" variant="outline">{{ t("ui.common.decrease") }}</Button>
+          <Button
+            @click="decrease"
+            variant="ghost"
+            :disabled="currentPage === 0"
+            :class="{ 'opacity-0!': currentPage === 0 }"
+          >
+            <ChevronLeft class="h-4 w-4" />
+          </Button>
           <div class="flex min-w-0 flex-1 flex-col justify-center">
             <video
               v-if="lipSyncFiles?.[currentBeat?.id]"
@@ -36,7 +43,14 @@
               class="max-h-64 object-contain"
             />
           </div>
-          <Button @click="increase" variant="outline">{{ t("ui.common.increase") }}</Button>
+          <Button
+            @click="increase"
+            variant="ghost"
+            :disabled="currentPage === beats.length - 1"
+            :class="{ 'opacity-0!': currentPage === beats.length - 1 }"
+          >
+            <ChevronRight class="h-4 w-4" />
+          </Button>
         </div>
         <audio
           :src="audioFiles[currentLanguage]?.[currentBeat?.id]"

--- a/src/renderer/components/mulmo_viewer/tabs/slide_tab.vue
+++ b/src/renderer/components/mulmo_viewer/tabs/slide_tab.vue
@@ -1,10 +1,6 @@
 <template>
   <TabsContent value="slide" class="mt-4 max-h-[calc(90vh-7rem)] overflow-y-auto">
     <div class="border-border bg-muted/50 rounded-lg border p-8 text-center">
-      <div class="mb-2 flex items-center justify-center gap-2">
-        <SelectLanguage v-model="currentLanguage" :languages="languages" />
-        <Button variant="outline" @click="generateLocalize">{{ t("ui.actions.generate") }}</Button>
-      </div>
       <div v-if="beats.length === 0">
         <FileImage :size="64" class="text-muted-foreground mx-auto mb-4" />
         <p class="mb-2 text-lg font-medium">{{ t("project.productTabs.slide.title") }}</p>
@@ -48,6 +44,9 @@
             <ChevronRight class="h-4 w-4" />
           </Button>
         </div>
+        <div class="text-muted-foreground mt-1 text-sm">
+          {{ t("project.productTabs.slide.details", { pages: beats.length, current: currentPage + 1 }) }}
+        </div>
         <audio
           :src="audioFiles[currentLanguage]?.[currentBeat?.id]"
           v-if="!!audioFiles[currentLanguage]?.[currentBeat?.id]"
@@ -68,10 +67,10 @@
                 t("ui.common.noLang"))
           }}
         </div>
-      </div>
-
-      <div class="text-muted-foreground mt-4 text-sm">
-        {{ t("project.productTabs.slide.details", { pages: beats.length, current: currentPage + 1 }) }}
+        <div class="mt-2 flex items-center justify-center gap-2">
+          <SelectLanguage v-model="currentLanguage" :languages="languages" />
+          <Button variant="outline" @click="generateLocalize">{{ t("ui.actions.generate") }}</Button>
+        </div>
       </div>
     </div>
   </TabsContent>

--- a/src/renderer/components/mulmo_viewer/tabs/slide_tab.vue
+++ b/src/renderer/components/mulmo_viewer/tabs/slide_tab.vue
@@ -35,17 +35,17 @@
               :src="imageFiles?.[currentBeat?.id]"
               class="max-h-64 object-contain"
             />
-            <audio
-              :src="audioFiles[currentLanguage]?.[currentBeat?.id]"
-              v-if="!!audioFiles[currentLanguage]?.[currentBeat?.id]"
-              controls
-              class="mx-auto mt-2"
-              @ended="handleAudioEnded"
-              ref="audioRef"
-            />
           </div>
           <Button @click="increase" variant="outline">{{ t("ui.common.increase") }}</Button>
         </div>
+        <audio
+          :src="audioFiles[currentLanguage]?.[currentBeat?.id]"
+          v-if="!!audioFiles[currentLanguage]?.[currentBeat?.id]"
+          controls
+          class="mx-auto mt-2 w-full max-w-full"
+          @ended="handleAudioEnded"
+          ref="audioRef"
+        />
         {{
           isScriptLang
             ? currentBeat?.text

--- a/src/renderer/components/mulmo_viewer/tabs/slide_tab.vue
+++ b/src/renderer/components/mulmo_viewer/tabs/slide_tab.vue
@@ -47,6 +47,10 @@
         <div class="text-muted-foreground mt-1 text-sm">
           {{ t("project.productTabs.slide.details", { pages: beats.length, current: currentPage + 1 }) }}
         </div>
+        <label class="my-2 mr-4 flex items-center justify-end gap-2 text-sm">
+          <Checkbox v-model="autoPlay" />
+          <span class="text-sm">{{ t("project.productTabs.slide.autoPlay") }}</span>
+        </label>
         <audio
           :src="audioFiles[currentLanguage]?.[currentBeat?.id]"
           v-if="!!audioFiles[currentLanguage]?.[currentBeat?.id]"
@@ -55,11 +59,7 @@
           @ended="handleAudioEnded"
           ref="audioRef"
         />
-        <label class="ml-4 flex items-center gap-2 text-sm">
-          <Checkbox v-model="autoPlay" />
-          <span class="text-sm">{{ t("project.productTabs.slide.autoPlay") }}</span>
-        </label>
-        <div class="bg-foreground/5 mt-4 rounded-lg p-2 text-sm">
+        <div class="bg-foreground/5 mt-2 rounded-lg p-2 text-sm">
           {{
             isScriptLang
               ? currentBeat?.text

--- a/src/renderer/components/mulmo_viewer/tabs/slide_tab.vue
+++ b/src/renderer/components/mulmo_viewer/tabs/slide_tab.vue
@@ -2,10 +2,6 @@
   <TabsContent value="slide" class="mt-4 max-h-[calc(90vh-7rem)] overflow-y-auto">
     <div class="border-border bg-muted/50 rounded-lg border p-8 text-center">
       <div class="mb-2 flex items-center justify-center gap-2">
-        <label>
-          <Checkbox v-model="autoPlay" />
-          {{ t("project.productTabs.slide.autoPlay") }}
-        </label>
         <SelectLanguage v-model="currentLanguage" :languages="languages" />
         <Button variant="outline" @click="generateLocalize">{{ t("ui.actions.generate") }}</Button>
       </div>
@@ -60,12 +56,18 @@
           @ended="handleAudioEnded"
           ref="audioRef"
         />
-        {{
-          isScriptLang
-            ? currentBeat?.text
-            : (mulmoMultiLinguals?.[currentBeatId]?.["multiLingualTexts"]?.[currentLanguage]?.text ??
-              t("ui.common.noLang"))
-        }}
+        <label class="ml-4 flex items-center gap-2 text-sm">
+          <Checkbox v-model="autoPlay" />
+          <span class="text-sm">{{ t("project.productTabs.slide.autoPlay") }}</span>
+        </label>
+        <div class="bg-foreground/5 mt-4 rounded-lg p-2 text-sm">
+          {{
+            isScriptLang
+              ? currentBeat?.text
+              : (mulmoMultiLinguals?.[currentBeatId]?.["multiLingualTexts"]?.[currentLanguage]?.text ??
+                t("ui.common.noLang"))
+          }}
+        </div>
       </div>
 
       <div class="text-muted-foreground mt-4 text-sm">
@@ -78,7 +80,7 @@
 <script setup lang="ts">
 import { ref, watch, computed } from "vue";
 import { useI18n } from "vue-i18n";
-import { FileImage } from "lucide-vue-next";
+import { FileImage, ChevronLeft, ChevronRight } from "lucide-vue-next";
 import { type MultiLingualTexts, beatId } from "mulmocast/browser";
 import { sleep } from "graphai";
 


### PR DESCRIPTION
Slideタブのデザインが少し崩れているように感じたので微調整しました。

- 画像のはみ出し抑制
- 左右アイコンを矢印に変更。最初と最後のページでは非表示
- auto playやslide枚数などを関係するUIと近づける
- scriptを見やすく

|Before|After|
|---|---|
| <img width="874" height="1728" alt="CleanShot 2025-09-01 at 21 58 32@2x" src="https://github.com/user-attachments/assets/0093f482-c81c-456f-ba01-4cd8fd3fca57" /> | <img width="874" height="1492" alt="CleanShot 2025-09-01 at 22 01 51@2x" src="https://github.com/user-attachments/assets/079ad519-81f0-48ab-bf68-eaddde2527a9" /> |






<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added slide details showing current page out of total.
  * Introduced bottom control group for language selection and content generation.
  * Navigation now disables at first/last slide to prevent out-of-bounds paging.

* Style
  * Reworked slide tab UI with icon-based chevron navigation and clearer disabled states.
  * Moved translation into a dedicated panel and relocated audio controls after details.
  * Updated layout for improved spacing and responsiveness.

* Refactor
  * Restructured content and control placement to align with the new layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->