### PR TITLE
auto play after page transition

### DIFF
--- a/src/renderer/components/mulmo_viewer/tabs/slide_tab.vue
+++ b/src/renderer/components/mulmo_viewer/tabs/slide_tab.vue
@@ -137,6 +137,9 @@ const currentBeatId = computed(() => {
 const increase = () => {
   if (currentPage.value + 1 < beats.value.length) {
     currentPage.value = currentPage.value + 1;
+    if (autoPlay.value) {
+      waitAndPlay();
+    }
     return true;
   }
   return false;
@@ -144,15 +147,22 @@ const increase = () => {
 const decrease = () => {
   if (currentPage.value > 0) {
     currentPage.value = currentPage.value - 1;
+    if (autoPlay.value) {
+      waitAndPlay();
+    }
+  }
+};
+
+const waitAndPlay = async () => {
+  await sleep(500);
+  if (audioRef.value) {
+    audioRef.value.play();
   }
 };
 
 const handleAudioEnded = async () => {
   if (autoPlay.value && increase()) {
-    await sleep(500);
-    if (audioRef.value) {
-      audioRef.value.play();
-    }
+    waitAndPlay();
   }
 };
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of audio autoplay when navigating between slides. Playback now starts automatically after a brief delay when enabled, reducing cases where audio failed to begin after a page change.
  * Ensures autoplay resumes correctly after an audio track ends and when moving both forward and backward through slides, providing a smoother, more consistent listening experience during slide navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->