### PR TITLE
update slide

### DIFF
--- a/src/renderer/components/mulmo_viewer/tabs/slide_tab.vue
+++ b/src/renderer/components/mulmo_viewer/tabs/slide_tab.vue
@@ -47,6 +47,14 @@
         <div class="text-muted-foreground mt-1 text-sm">
           {{ t("project.productTabs.slide.details", { pages: beats.length, current: currentPage + 1 }) }}
         </div>
+        <div class="bg-foreground/5 mt-2 rounded-lg p-2 text-sm">
+          {{
+            isScriptLang
+              ? currentBeat?.text
+              : (mulmoMultiLinguals?.[currentBeatId]?.["multiLingualTexts"]?.[currentLanguage]?.text ??
+                t("ui.common.noLang"))
+          }}
+        </div>
         <label class="my-2 mr-4 flex items-center justify-end gap-2 text-sm">
           <Checkbox v-model="autoPlay" />
           <span class="text-sm">{{ t("project.productTabs.slide.autoPlay") }}</span>
@@ -59,14 +67,6 @@
           @ended="handleAudioEnded"
           ref="audioRef"
         />
-        <div class="bg-foreground/5 mt-2 rounded-lg p-2 text-sm">
-          {{
-            isScriptLang
-              ? currentBeat?.text
-              : (mulmoMultiLinguals?.[currentBeatId]?.["multiLingualTexts"]?.[currentLanguage]?.text ??
-                t("ui.common.noLang"))
-          }}
-        </div>
         <div class="mt-2 flex items-center justify-center gap-2">
           <SelectLanguage v-model="currentLanguage" :languages="languages" />
           <Button variant="outline" @click="generateLocalize">{{ t("ui.actions.generate") }}</Button>

--- a/src/renderer/i18n/en.ts
+++ b/src/renderer/i18n/en.ts
@@ -415,7 +415,7 @@ const lang = {
         description: "Slide format display and navigation",
         start: "Start Slideshow",
         export: "Export Images",
-        details: "{current} / {pages} slides",
+        details: "{current} / {pages}",
         autoPlay: "Auto Play",
       },
     },

--- a/src/renderer/i18n/ja.ts
+++ b/src/renderer/i18n/ja.ts
@@ -414,7 +414,7 @@ const lang = {
         description: "スライド形式の表示とナビゲーション",
         start: "スライドショーの開始",
         export: "スライドをエクスポート",
-        details: "{current} / {pages} スライド",
+        details: "{current} / {pages}",
         autoPlay: "自動再生",
       },
     },


### PR DESCRIPTION
"1/N slides" は、単に"1/N"に変更

Textは画像のすぐ下に表示（Play Barの上）

#693

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Repositioned the slide text display above the audio controls for clearer reading order.
  * Removed a duplicate text block that previously appeared below the audio controls.

* **Localization**
  * Updated slide details label to show “{current} / {pages}” (removed the “slides” unit) in English.
  * Updated slide details label to show “{current} / {pages}” (removed “スライド”) in Japanese.
  * Ensured text display respects script language vs. multilingual modes with fallback when no language is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->