### PR TITLE
update

### DIFF
--- a/src/renderer/components/mulmo_viewer/tabs/slide_tab.vue
+++ b/src/renderer/components/mulmo_viewer/tabs/slide_tab.vue
@@ -54,6 +54,12 @@
               : (mulmoMultiLinguals?.[currentBeatId]?.["multiLingualTexts"]?.[currentLanguage]?.text ??
                 t("ui.common.noLang"))
           }}
+          <Button
+            variant="outline"
+            @click="generateLocalize"
+            v-if="!isScriptLang && !mulmoMultiLinguals?.[currentBeatId]?.['multiLingualTexts']?.[currentLanguage]?.text"
+            >{{ t("ui.actions.translate") }}</Button
+          >
         </div>
         <label class="my-2 mr-4 flex items-center justify-end gap-2 text-sm">
           <Checkbox v-model="autoPlay" />
@@ -71,7 +77,7 @@
         />
         <div class="mt-2 flex items-center justify-center gap-2">
           <SelectLanguage v-model="currentLanguage" :languages="languages" />
-          <Button variant="outline" @click="generateLocalize">{{ t("ui.actions.generate") }}</Button>
+          <Button variant="outline" @click="generateLocalize">{{ t("ui.actions.translate") }}</Button>
         </div>
       </div>
     </div>

--- a/src/renderer/i18n/en.ts
+++ b/src/renderer/i18n/en.ts
@@ -61,7 +61,7 @@ const lang = {
       decrease: "-",
       increase: "+",
 
-      noLang: "翻訳されていません",
+      noLang: "Not translated",
     },
 
     // Common actions (placeholder pairs)
@@ -76,6 +76,7 @@ const lang = {
       cancel: "Cancel",
       ok: "OK",
       runningThing: "{thing} is running",
+      translate: "Translate",
 
       // Media actions (placeholder pairs)
       play: "Play",

--- a/src/renderer/i18n/ja.ts
+++ b/src/renderer/i18n/ja.ts
@@ -76,6 +76,7 @@ const lang = {
       cancel: "キャンセル",
       ok: "OK",
       runningThing: "{thing}を実行中",
+      translate: "翻訳する",
 
       // Media actions (placeholder pairs)
       play: "再生",


### PR DESCRIPTION
- Generate ボタンは”Translate（翻訳する）”に変更
- そのTranslateボタンは、"翻訳されていません”の右横に表示。

#693

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a Translate button that appears only when a translation is missing and the current language is translatable. It generates the translation, creates audio, and downloads it.
  - Renamed the bottom action label from “Generate” to “Translate” for clarity.

- Localization
  - Updated English strings, including changing “Not translated” messaging.
  - Added Japanese translation for the new Translate action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->