### PR TITLE
Add UI for Default speaker selection

### DIFF
--- a/src/renderer/i18n/en.ts
+++ b/src/renderer/i18n/en.ts
@@ -543,6 +543,8 @@ const lang = {
     },
     speechParams: {
       title: "Speech Parameters",
+      defaultSpeaker: "Default Speaker",
+      speakers: "Speakers",
       language: "Language",
       displayName: "Display Name",
       voiceId: "Voice ID",

--- a/src/renderer/i18n/ja.ts
+++ b/src/renderer/i18n/ja.ts
@@ -543,6 +543,8 @@ const lang = {
     },
     speechParams: {
       title: "音声設定",
+      defaultSpeaker: "標準のスピーカー",
+      speakers: "スピーカー一覧",
       language: "言語",
       displayName: "表示名",
       voiceId: "音声ID",

--- a/src/renderer/pages/project/script_editor/parameters/speech_params.vue
+++ b/src/renderer/pages/project/script_editor/parameters/speech_params.vue
@@ -53,7 +53,7 @@
             <Label>{{ t("ui.common.provider") }}</Label>
             <Select
               :model-value="speaker.provider || defaultSpeechProvider"
-              @update:model-value="(value) => handleProviderChange(name, String(value) as Provider)"
+              @update:model-value="(value) => handleProviderChange(name, value)"
             >
               <SelectTrigger>
                 <SelectValue />
@@ -208,6 +208,7 @@ const getVoiceList = (provider: string) => {
 
 const updateSpeechParams = (updates: Partial<NonNullable<SpeechParams>>): void => {
   const baseParams = props.speechParams || {
+    provider: "openai" as Provider,
     speakers: {},
   };
 

--- a/src/renderer/pages/project/script_editor/parameters/speech_params.vue
+++ b/src/renderer/pages/project/script_editor/parameters/speech_params.vue
@@ -2,6 +2,25 @@
   <Card class="p-4">
     <h4 class="mb-3 font-medium">{{ t("parameters.speechParams.title") }}</h4>
     <div v-if="speechParams" class="space-y-4">
+      <div v-if="speechParams.speakers && Object.keys(speechParams.speakers).length" class="mb-2">
+        <Label class="mb-2">{{ t("parameters.speechParams.defaultSpeaker") }}</Label>
+        <Select
+          :model-value="defaultSpeakerName"
+          @update:model-value="(value) => handleDefaultSpeakerChange(String(value))"
+        >
+          <SelectTrigger class="h-8">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem v-for="(_, name) in speechParams.speakers" :key="name" :value="name">
+              {{ name }}
+            </SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+      <div v-if="speechParams.speakers && Object.keys(speechParams.speakers).length" class="mt-4 mb-2">
+        <Label class="mb-2">{{ t("parameters.speechParams.speakers") }}</Label>
+      </div>
       <div
         v-if="speechParams.speakers"
         v-for="(speaker, name) in speechParams.speakers"
@@ -34,7 +53,7 @@
             <Label>{{ t("ui.common.provider") }}</Label>
             <Select
               :model-value="speaker.provider || defaultSpeechProvider"
-              @update:model-value="(value) => handleProviderChange(name, value)"
+              @update:model-value="(value) => handleProviderChange(name, String(value) as Provider)"
             >
               <SelectTrigger>
                 <SelectValue />
@@ -179,7 +198,7 @@ const { t } = useI18n();
 
 const selectedLanguages = ref<Record<string, string>>({});
 
-const speakers = computed(() => props.speechParams?.speakers || {});
+const speakers = computed<Record<string, Speaker>>(() => props.speechParams?.speakers || {});
 const speakerCount = computed(() => Object.keys(speakers.value).length);
 const canDeleteSpeaker = computed(() => speakerCount.value > 1);
 
@@ -189,7 +208,6 @@ const getVoiceList = (provider: string) => {
 
 const updateSpeechParams = (updates: Partial<NonNullable<SpeechParams>>): void => {
   const baseParams = props.speechParams || {
-    provider: "openai" as Provider,
     speakers: {},
   };
 
@@ -241,6 +259,21 @@ const handleDisplayNameChange = (name: string, language: string, value: string) 
       [language]: value,
     },
   });
+};
+
+const defaultSpeakerName = computed(() => {
+  const entries = Object.entries(speakers.value);
+  if (entries.length === 0) return "";
+  const found = entries.find(([, s]) => Boolean(s.isDefault));
+  return found ? found[0] : entries[0][0];
+});
+
+const handleDefaultSpeakerChange = (name: string) => {
+  const updated: NonNullable<SpeechParams>["speakers"] = {};
+  for (const [key, sp] of Object.entries(speakers.value)) {
+    updated[key] = { ...sp, isDefault: key === name } as Speaker;
+  }
+  updateSpeakers(updated);
 };
 
 const handleDeleteSpeaker = (name: string) => {
@@ -311,13 +344,13 @@ const handleAddSpeaker = () => {
 
 const initializeSpeechParams = () => {
   updateSpeechParams({
-    provider: defaultSpeechProvider,
     speakers: {
       Presenter: {
         voiceId: DEFAULT_VOICE_IDS[defaultSpeechProvider],
         displayName: {
           [SPEECH_DEFAULT_LANGUAGE]: "Presenter",
         },
+        isDefault: true,
       },
     },
   });


### PR DESCRIPTION
close #593

default speakerの設定UIを追加しました

<img width="500" height="549" alt="image" src="https://github.com/user-attachments/assets/6059cad9-5a68-4620-9111-1644daa25cfd" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a default speaker selector in speech settings when multiple speakers are available.
  * Preselects a default speaker, which users can change at any time.
  * Improved clarity with a dedicated label for the speakers section.
  * Added English and Japanese UI labels for “Default Speaker” and “Speakers” to enhance localization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->