### PR TITLE
update mulmo viewer menu

### DIFF
--- a/src/renderer/components/mulmo_viewer/mulmo_viewer.vue
+++ b/src/renderer/components/mulmo_viewer/mulmo_viewer.vue
@@ -73,8 +73,15 @@
           <ChevronRight class="h-4 w-4" />
         </Button>
       </div>
-      <div class="text-muted-foreground mt-1 text-right text-sm">
-        {{ t("project.productTabs.slide.details", { pages: beats.length, current: currentPage + 1 }) }}
+      <div class="text-muted-foreground mt-1 flex justify-end items-center gap-4 text-sm">
+        <SelectLanguage v-model="currentLanguage" :languages="languages" />
+        <label class="flex items-center gap-2">
+          <Checkbox v-model="autoPlay" />
+          <span class="text-sm">{{ t("project.productTabs.slide.autoPlay") }}</span>
+        </label>
+        <div>
+          {{ t("project.productTabs.slide.details", { pages: beats.length, current: currentPage + 1 }) }}
+        </div>
       </div>
       <div class="bg-foreground/5 mt-2 rounded-lg p-2 text-sm">
         {{
@@ -90,10 +97,6 @@
           >{{ t("ui.actions.translate") }}</Button
         >
       </div>
-      <label class="my-2 mr-4 flex items-center justify-end gap-2 text-sm">
-        <Checkbox v-model="autoPlay" />
-        <span class="text-sm">{{ t("project.productTabs.slide.autoPlay") }}</span>
-      </label>
       <div v-if="false">
         <audio
           :src="audioFiles[currentLanguage]?.[currentBeat?.id]"
@@ -107,7 +110,6 @@
         />
       </div>
       <div class="mt-2 flex items-center justify-center gap-2">
-        <SelectLanguage v-model="currentLanguage" :languages="languages" />
         <Button variant="outline" @click="generateLocalize">{{ t("ui.actions.translate") }}</Button>
       </div>
     </div>

--- a/src/renderer/components/mulmo_viewer/mulmo_viewer.vue
+++ b/src/renderer/components/mulmo_viewer/mulmo_viewer.vue
@@ -73,7 +73,7 @@
           <ChevronRight class="h-4 w-4" />
         </Button>
       </div>
-      <div class="text-muted-foreground mt-1 flex justify-end items-center gap-4 text-sm">
+      <div class="text-muted-foreground mt-1 flex items-center justify-end gap-4 text-sm">
         <SelectLanguage v-model="currentLanguage" :languages="languages" />
         <label class="flex items-center gap-2">
           <Checkbox v-model="autoPlay" />


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Reorganized slide viewer header: moved language selector and autoplay checkbox from the bottom to the top-right and grouped them with slide details.
  - Removed the bottom control area; translate button area no longer includes the language selector.
  - Slide details (current page/total pages) remain unchanged.

- Style
  - Improved spacing and alignment using a flexible layout for a cleaner, more consistent controls area.
  - Enhanced readability and quick access to language and autoplay settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->