### PR TITLE
separate lang pulldown and button

### DIFF
--- a/src/renderer/components/mulmo_viewer/mulmo_viewer.vue
+++ b/src/renderer/components/mulmo_viewer/mulmo_viewer.vue
@@ -79,7 +79,7 @@
         }}
         <Button
           variant="outline"
-          @click="generateLocalizeAudio"
+          @click="generateLocalizeText"
           v-if="!isScriptLang && !mulmoMultiLinguals?.[currentBeatId]?.['multiLingualTexts']?.[textLanguage]?.text"
           >{{ t("ui.actions.translate") }}</Button
         >

--- a/src/renderer/components/mulmo_viewer/mulmo_viewer.vue
+++ b/src/renderer/components/mulmo_viewer/mulmo_viewer.vue
@@ -43,27 +43,6 @@
         >
           <ChevronLeft class="h-4 w-4" />
         </Button>
-        <div class="flex min-w-0 flex-1 flex-col justify-center">
-          <div>
-            <video
-              v-if="lipSyncFiles?.[currentBeat?.id]"
-              :src="lipSyncFiles?.[currentBeat?.id]"
-              controls
-              class="max-h-64 object-contain"
-            />
-            <video
-              v-else-if="movieFiles?.[currentBeat?.id]"
-              :src="movieFiles?.[currentBeat?.id]"
-              controls
-              class="max-h-64 object-contain"
-            />
-            <img
-              v-else-if="imageFiles?.[currentBeat?.id]"
-              :src="imageFiles?.[currentBeat?.id]"
-              class="max-h-64 object-contain"
-            />
-          </div>
-        </div>
         <Button
           @click="increase"
           variant="ghost"
@@ -73,9 +52,10 @@
           <ChevronRight class="h-4 w-4" />
         </Button>
       </div>
+      <!-- media manu -->
       <div class="text-muted-foreground mt-1 flex items-center justify-end gap-4 text-sm">
         <SelectLanguage v-model="currentLanguage" :languages="languages" />
-        <Button variant="outline" @click="generateLocalizeAudio">{{ t("ui.actions.generateAudio") }}</Button>
+        <Button variant="outline" @click="generateLocalizeAudio"  v-if="!audioFiles[currentLanguage]?.[currentBeat?.id]" >{{ t("ui.actions.generateAudio") }}</Button>
         <label class="flex items-center gap-2">
           <Checkbox v-model="autoPlay" />
           <span class="text-sm">{{ t("project.productTabs.slide.autoPlay") }}</span>

--- a/src/renderer/components/mulmo_viewer/mulmo_viewer.vue
+++ b/src/renderer/components/mulmo_viewer/mulmo_viewer.vue
@@ -55,7 +55,12 @@
       <!-- media manu -->
       <div class="text-muted-foreground mt-1 flex items-center justify-end gap-4 text-sm">
         <SelectLanguage v-model="currentLanguage" :languages="languages" />
-        <Button variant="outline" @click="generateLocalizeAudio"  v-if="!audioFiles[currentLanguage]?.[currentBeat?.id]" >{{ t("ui.actions.generateAudio") }}</Button>
+        <Button
+          variant="outline"
+          @click="generateLocalizeAudio"
+          v-if="!audioFiles[currentLanguage]?.[currentBeat?.id]"
+          >{{ t("ui.actions.generateAudio") }}</Button
+        >
         <label class="flex items-center gap-2">
           <Checkbox v-model="autoPlay" />
           <span class="text-sm">{{ t("project.productTabs.slide.autoPlay") }}</span>

--- a/src/renderer/i18n/en.ts
+++ b/src/renderer/i18n/en.ts
@@ -63,6 +63,7 @@ const lang = {
 
       noLang: "Not translated",
       noMedia: "No Media",
+      noAudio: "音声なし",
     },
 
     // Common actions (placeholder pairs)

--- a/src/renderer/i18n/ja.ts
+++ b/src/renderer/i18n/ja.ts
@@ -63,6 +63,7 @@ const lang = {
 
       noLang: "翻訳されていません",
       noMedia: "No Media",
+      noAudio: "音声なし",
     },
 
     // Common actions (placeholder pairs)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added a unified media player and a Generate Audio button to create and download localized audio for the selected audio language.
  - Introduced a separate text language selector, independent from the audio language.

- Improvements
  - Text content now updates across the viewer based on the chosen text language.
  - Language controls clarified: text selector moved to the bottom area; audio selector remains at the top.
  - Translation and audio generation flows streamlined; obsolete inline audio element removed.

- Localization
  - Added a "No Audio" translation entry for supported languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->