### PR TITLE
fix(chat): make timestamps follow UI language (vue-i18n locale)

### DIFF
--- a/src/renderer/pages/project/chat/date_format.ts
+++ b/src/renderer/pages/project/chat/date_format.ts
@@ -1,5 +1,5 @@
 import { computed } from "vue";
-import { useMulmoGlobalStore } from "@/store";
+import { useI18n } from "vue-i18n";
 
 import localizedFormat from "dayjs/plugin/localizedFormat";
 import "dayjs/locale/ja";
@@ -8,12 +8,12 @@ import dayjs from "dayjs";
 
 dayjs.extend(localizedFormat);
 
-export const useFormatedDate = (date: Date, format: string) => {
-  const globalStore = useMulmoGlobalStore();
+// Format chat timestamps using the current UI locale (APP_LANGUAGE)
+export const useFormatedDate = (date: Date | number, format: string) => {
+  const { locale } = useI18n();
 
   const formatedTime = computed(() => {
-    dayjs.locale(globalStore.settings.MAIN_LANGUAGE);
-    return dayjs(date).format(format);
+    return dayjs(date).locale(locale.value).format(format);
   });
   return { formatedTime };
 };


### PR DESCRIPTION
#596 のQA中です。
AI Chat 内の言語を切り替えても、Setting から言語を切り替えても US 表示しか表示されないため修正しました。

AI Chat 内の時刻は Setting の言語（現在は、日本語、英語のみ）と連動するようにしました。

## 概要

チャットの日時表示が UI 言語（APP_LANGUAGE / vue-i18n の locale）に追従せず、言語を切り替えても英語・日本語の表示形式が変わらない問題を修正しました。

## 原因

src/renderer/pages/project/chat/date_format.ts で dayjs.locale(globalStore.settings.MAIN_LANGUAGE) を使用しており、UI 言語ではなく「スクリプトの主言語(MAIN_LANGUAGE)」に固定されていたため。

## 対応内容

- 日付フォーマッタを vue-i18n の現在ロケールを参照する実装に変更。
  - useI18n().locale を使用し、dayjs(date).locale(locale.value).format(format) で出力。
  - 引数型を Date | number に拡張（props.time ?? Date.now() の数値も安全に処理）。
- 対象ファイル:
  - src/renderer/pages/project/chat/date_format.ts:1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Chat dates now automatically format according to your selected app language/locale.
  * Consistent date display across regions (e.g., month/day order, weekday names).

* Refactor
  * Switched date formatting to use the app’s i18n locale instead of a separate global language setting.
  * Expanded date handling to accept numeric timestamps for more robust input support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->