### PR TITLE
update design 

### DIFF
--- a/src/renderer/i18n/en.ts
+++ b/src/renderer/i18n/en.ts
@@ -533,6 +533,7 @@ const lang = {
       badge: "Vision",
       label: "Vision",
       placeholder: "JSON data",
+      stylePlaceholder: "Please select a style",
     },
   },
 

--- a/src/renderer/i18n/ja.ts
+++ b/src/renderer/i18n/ja.ts
@@ -533,6 +533,7 @@ const lang = {
       badge: "Vision",
       label: "Vision",
       placeholder: "スライドに合わせたjsonデータ",
+      stylePlaceholder: "スタイルを選択してください",
     },
   },
 

--- a/src/renderer/pages/project/generate.vue
+++ b/src/renderer/pages/project/generate.vue
@@ -32,7 +32,7 @@
 import { ref, watch } from "vue";
 import { useMulmoEventStore } from "../../store";
 import { notifyProgress } from "@/lib/notification";
-import { FileText, Monitor, Globe, Volume2Icon } from "lucide-vue-next";
+import { FileText, Monitor, Volume2Icon } from "lucide-vue-next";
 import { Button } from "@/components/ui/button";
 import { getConcurrentTaskStatusMessageComponent } from "./concurrent_task_status_message";
 import { Checkbox } from "@/components/ui/checkbox";

--- a/src/renderer/pages/project/generate.vue
+++ b/src/renderer/pages/project/generate.vue
@@ -19,7 +19,7 @@
         >
           <div class="mb-0 flex items-center justify-center gap-2">
             <Monitor :size="24" v-if="options.movie" />
-            <Globe :size="24" v-if="options.audio" />
+            <Volume2Icon :size="24" v-if="options.audio" />
             <FileText :size="24" v-if="options.pdfSlide || options.pdfHandout" />
           </div>
           <span>{{ t("project.generate.generateContents") }}</span>
@@ -32,7 +32,7 @@
 import { ref, watch } from "vue";
 import { useMulmoEventStore } from "../../store";
 import { notifyProgress } from "@/lib/notification";
-import { FileText, Monitor, Globe } from "lucide-vue-next";
+import { FileText, Monitor, Globe, Volume2Icon } from "lucide-vue-next";
 import { Button } from "@/components/ui/button";
 import { getConcurrentTaskStatusMessageComponent } from "./concurrent_task_status_message";
 import { Checkbox } from "@/components/ui/checkbox";

--- a/src/renderer/pages/project/script_editor/beat_editor.vue
+++ b/src/renderer/pages/project/script_editor/beat_editor.vue
@@ -204,7 +204,7 @@
             :modelValue="beat.enableLipSync"
             @update:model-value="(value) => update('enableLipSync', value)"
           />
-          <Label class="mb-2 block">{{ t("beat.lipSync.label") }}: </Label>
+          <Label class="mb-2 block">{{ t("beat.lipSync.label") }} </Label>
         </div>
       </div>
       <!-- right: lipSync preview -->

--- a/src/renderer/pages/project/script_editor/beat_editors/vision.vue
+++ b/src/renderer/pages/project/script_editor/beat_editors/vision.vue
@@ -1,6 +1,7 @@
 <template>
   <Label class="mb-1 block">{{ t("beat.vision.label") }}</Label>
   <VisionSelect
+    class="mb-2"
     :model-value="beat.image?.style"
     @update:model-value="(value) => update('image.style', String(value))"
   />

--- a/src/renderer/pages/project/script_editor/beat_editors/vision_select.vue
+++ b/src/renderer/pages/project/script_editor/beat_editors/vision_select.vue
@@ -2,7 +2,7 @@
   <div class="template-dropdown-container flex items-center gap-4">
     <Select :model-value="modelValue" @update:modelValue="updateValue">
       <SelectTrigger class="w-auto">
-        <SelectValue />
+        <SelectValue :placeholder="t('beat.vision.stylePlaceholder')" />
       </SelectTrigger>
       <SelectContent>
         <SelectItem v-for="name in names" :key="name" :value="name">
@@ -16,6 +16,9 @@
 <script setup lang="ts">
 import { toolsToTemplateNames, tools } from "mulmocast-vision/lib/browser";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { useI18n } from "vue-i18n";
+
+const { t } = useI18n();
 
 defineProps<{
   modelValue: string;


### PR DESCRIPTION
デザイン少し追加しました

1 place holder 追加 + i18n 
2 select a style と text area の間に余白追加
<img width="1188" height="600" alt="CleanShot 2025-09-06 at 22 52 48@2x" src="https://github.com/user-attachments/assets/d3b23723-a202-47bc-8a6b-7ec6f64ea877" />

3 リップシンクのチェックボックスラベルの後に不要な「:」があったので削除
<img width="884" height="580" alt="CleanShot 2025-09-06 at 22 54 52@2x" src="https://github.com/user-attachments/assets/be00d87c-f897-42b6-9efe-819b979f110c" />

4 generate pane
音声のアイコンを地球儀から変更（成果物タブのアイコンに揃えた）
<img width="934" height="582" alt="CleanShot 2025-09-06 at 22 55 57@2x" src="https://github.com/user-attachments/assets/4125fd20-c739-41eb-a026-f62551138cd7" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Localized placeholder text added for the Vision style selector (English and Japanese).

- Style
  - Replaced the audio icon in the generate button for clearer representation.
  - Increased spacing below the Vision style selector for improved layout.
  - Removed the trailing colon after the lip sync label for cleaner typography.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->