### PR TITLE
Improve ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,8 @@ jobs:
   content-generation-test:
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    container:
+      image: mcr.microsoft.com/playwright:v1.55.0-jammy
 
     steps:
       - name: Checkout code
@@ -63,8 +65,6 @@ jobs:
           cache: 'yarn'
       - name: Install dependencies
         run: yarn install --frozen-lockfile
-      - run: npx playwright install-deps && npx playwright install chromium
-      - run: yarn package
       - run: xvfb-run -a --server-args="-screen 0 1024x768x24" npx ts-node test/automated_serial_generation_e2e_test.ts
         env:
           CI: true


### PR DESCRIPTION
E2EテストのCIの実行時間が長くリードタイムに影響するので、改善しました。

- 不要なpackagingを削除
- playwrightとbrowserのinstallを削除し、containerを利用

平均2分ほど早くなると思います。