### PR TITLE
Add GitHub Issues Template

### DIFF
--- a/.github/ISSUE_TEMPLATE/01_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/01_bug_report.yml
@@ -1,0 +1,145 @@
+name: Bug report
+description: Create a report to help us improve
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+
+  - type: textarea
+    id: bug-description
+    attributes:
+      label: Describe the bug
+      description: A clear and concise description of what the bug is.
+      placeholder: Tell us what you see!
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: To Reproduce
+      description: Steps to reproduce the behavior
+      placeholder: |
+        1. Run command: mulmo ...
+        2. With options: ...
+        3. See error
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: A clear and concise description of what you expected to happen.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: install-method
+    attributes:
+      label: Installation Method
+      description: How did you install MulmoCast?
+      options:
+        - npm/yarn global install (mulmocast package)
+        - GitHub source (cloned repository)
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    id: cli-version
+    attributes:
+      label: Version
+      description: |
+        - For npm: Run `mulmo --version`
+        - For GitHub: Check package.json or git commit hash
+      placeholder: "e.g., 1.2.2 or commit abc123"
+    validations:
+      required: true
+
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots
+      description: If applicable, add screenshots to help explain your problem.
+    validations:
+      required: false
+
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating System
+      description: What OS are you using?
+      options:
+        - macOS
+        - Windows
+        - Linux
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    id: os-version
+    attributes:
+      label: OS Version
+      description: e.g., macOS 14.0, Windows 11, Ubuntu 22.04
+      placeholder: "Version"
+    validations:
+      required: false
+
+  - type: input
+    id: node-version
+    attributes:
+      label: Node.js Version
+      description: Run `node --version`
+      placeholder: "e.g., v20.10.0"
+    validations:
+      required: true
+
+  - type: textarea
+    id: mulmo-script
+    attributes:
+      label: MulmoScript Used
+      description: Paste your MulmoScript JSON inside the provided template below (replace the placeholder)
+      value: |
+        <details>
+        <summary>MulmoScript (click to expand)</summary>
+        
+        ```json
+        {
+          "title": "Replace this with your MulmoScript",
+          "beats": [...]
+        }
+        ```
+        
+        </details>
+    validations:
+      required: false
+
+  - type: textarea
+    id: error-output
+    attributes:
+      label: Error Output
+      description: Paste error messages or logs inside the provided template below
+      value: |
+        <details>
+        <summary>Error logs (click to expand)</summary>
+        
+        ```shell
+        Replace this with your error output
+        ```
+        
+        </details>
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Add any other context about the problem here (e.g., relevant .env settings without sensitive data).
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/01_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/01_bug_report.yml
@@ -41,12 +41,12 @@ body:
   - type: dropdown
     id: install-method
     attributes:
-      label: Installation Method
-      description: How did you install MulmoCast App?
+      label: How did you get the app?
+      description: How did you install or run the MulmoCast App?
       options:
-        - GitHub Actions macOS build (DMG download)
-        - GitHub Actions Windows build (installer download)
-        - Development build (yarn start from source)
+        - Downloaded from GitHub (macOS)
+        - Downloaded from GitHub (Windows)
+        - Built from source (yarn start / yarn package)
         - Other
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/01_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/01_bug_report.yml
@@ -2,6 +2,7 @@ name: Bug report
 description: Create a report to help us improve
 title: "[Bug]: "
 labels: ["bug"]
+projects: ["https://github.com/orgs/receptron/projects/3"] 
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/01_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/01_bug_report.yml
@@ -66,7 +66,12 @@ body:
     id: screenshots
     attributes:
       label: Screenshots
-      description: If applicable, add screenshots to help explain your problem.
+      description: |
+        If applicable, add screenshots to help explain your problem.
+        You can drag and drop images directly into this text area after creating the issue.
+      placeholder: |
+        Screenshots will help us understand the issue better.
+        After creating this issue, you can drag and drop image files here.
     validations:
       required: false
 

--- a/.github/ISSUE_TEMPLATE/01_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/01_bug_report.yml
@@ -18,6 +18,43 @@ body:
       required: true
 
   - type: textarea
+    id: project-files
+    attributes:
+      label: Project Files
+      description: If relevant, paste your project script or configuration inside the provided template below
+      value: |
+        <details>
+        <summary>Project Script/Configuration (click to expand)</summary>
+        
+        ```json
+        {
+          "title": "Replace this with your project script",
+          "beats": [...]
+        }
+        ```
+        
+        </details>
+    validations:
+      required: false
+
+  - type: textarea
+    id: error-output
+    attributes:
+      label: Error Output
+      description: Paste error messages, console logs, or error dialogs inside the provided template below
+      value: |
+        <details>
+        <summary>Error logs/dialogs (click to expand)</summary>
+        
+        ```
+        Replace this with your error output or error dialog text
+        ```
+        
+        </details>
+    validations:
+      required: false
+
+  - type: textarea
     id: reproduction
     attributes:
       label: To Reproduce
@@ -62,19 +99,6 @@ body:
     validations:
       required: true
 
-  - type: textarea
-    id: screenshots
-    attributes:
-      label: Screenshots
-      description: |
-        If applicable, add screenshots to help explain your problem.
-        You can drag and drop images directly into this text area after creating the issue.
-      placeholder: |
-        Screenshots will help us understand the issue better.
-        After creating this issue, you can drag and drop image files here.
-    validations:
-      required: false
-
   - type: dropdown
     id: os
     attributes:
@@ -94,44 +118,6 @@ body:
       label: OS Version
       description: e.g., macOS 14.0, Windows 11, Ubuntu 22.04
       placeholder: "Version"
-    validations:
-      required: false
-
-
-  - type: textarea
-    id: project-files
-    attributes:
-      label: Project Files
-      description: If relevant, paste your project script or configuration inside the provided template below
-      value: |
-        <details>
-        <summary>Project Script/Configuration (click to expand)</summary>
-        
-        ```json
-        {
-          "title": "Replace this with your project script",
-          "beats": [...]
-        }
-        ```
-        
-        </details>
-    validations:
-      required: false
-
-  - type: textarea
-    id: error-output
-    attributes:
-      label: Error Output
-      description: Paste error messages, console logs, or error dialogs inside the provided template below
-      value: |
-        <details>
-        <summary>Error logs/dialogs (click to expand)</summary>
-        
-        ```
-        Replace this with your error output or error dialog text
-        ```
-        
-        </details>
     validations:
       required: false
 

--- a/.github/ISSUE_TEMPLATE/01_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/01_bug_report.yml
@@ -1,7 +1,7 @@
 name: Bug report
 description: Create a report to help us improve
 title: "[Bug]: "
-labels: ["type: bug", "source: community"]
+labels: ["bug", "source: community"]
 projects: ["receptron/3"]
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/01_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/01_bug_report.yml
@@ -23,10 +23,9 @@ body:
       label: To Reproduce
       description: Steps to reproduce the behavior
       placeholder: |
-        1. Open MulmoCast app
-        2. Create/open project
-        3. Perform action in GUI (e.g., generate content, edit script)
-        4. See error
+        1. Open project
+        2. Perform action in GUI (e.g., generate contents, edit script)
+        3. See error
     validations:
       required: true
 
@@ -57,6 +56,7 @@ body:
       label: App Version
       description: |
         - Check "About MulmoCast App" in the app menu
+        - For Downloaded from GitHub: please use PR number
         - For development build: Check package.json or git commit hash
       placeholder: "e.g., 1.2.27 or commit abc123"
     validations:

--- a/.github/ISSUE_TEMPLATE/01_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/01_bug_report.yml
@@ -23,9 +23,10 @@ body:
       label: To Reproduce
       description: Steps to reproduce the behavior
       placeholder: |
-        1. Run command: mulmo ...
-        2. With options: ...
-        3. See error
+        1. Open MulmoCast app
+        2. Create/open project
+        3. Perform action in GUI (e.g., generate content, edit script)
+        4. See error
     validations:
       required: true
 
@@ -41,22 +42,23 @@ body:
     id: install-method
     attributes:
       label: Installation Method
-      description: How did you install MulmoCast?
+      description: How did you install MulmoCast App?
       options:
-        - npm/yarn global install (mulmocast package)
-        - GitHub source (cloned repository)
+        - GitHub Actions macOS build (DMG download)
+        - GitHub Actions Windows build (installer download)
+        - Development build (yarn start from source)
         - Other
     validations:
       required: true
 
   - type: input
-    id: cli-version
+    id: app-version
     attributes:
-      label: Version
+      label: App Version
       description: |
-        - For npm: Run `mulmo --version`
-        - For GitHub: Check package.json or git commit hash
-      placeholder: "e.g., 1.2.2 or commit abc123"
+        - Check "About MulmoCast App" in the app menu
+        - For development build: Check package.json or git commit hash
+      placeholder: "e.g., 1.2.27 or commit abc123"
     validations:
       required: true
 
@@ -90,27 +92,19 @@ body:
     validations:
       required: false
 
-  - type: input
-    id: node-version
-    attributes:
-      label: Node.js Version
-      description: Run `node --version`
-      placeholder: "e.g., v20.10.0"
-    validations:
-      required: true
 
   - type: textarea
-    id: mulmo-script
+    id: project-files
     attributes:
-      label: MulmoScript Used
-      description: Paste your MulmoScript JSON inside the provided template below (replace the placeholder)
+      label: Project Files
+      description: If relevant, paste your project script or configuration inside the provided template below
       value: |
         <details>
-        <summary>MulmoScript (click to expand)</summary>
+        <summary>Project Script/Configuration (click to expand)</summary>
         
         ```json
         {
-          "title": "Replace this with your MulmoScript",
+          "title": "Replace this with your project script",
           "beats": [...]
         }
         ```
@@ -123,13 +117,13 @@ body:
     id: error-output
     attributes:
       label: Error Output
-      description: Paste error messages or logs inside the provided template below
+      description: Paste error messages, console logs, or error dialogs inside the provided template below
       value: |
         <details>
-        <summary>Error logs (click to expand)</summary>
+        <summary>Error logs/dialogs (click to expand)</summary>
         
-        ```shell
-        Replace this with your error output
+        ```
+        Replace this with your error output or error dialog text
         ```
         
         </details>
@@ -140,6 +134,6 @@ body:
     id: additional
     attributes:
       label: Additional context
-      description: Add any other context about the problem here (e.g., relevant .env settings without sensitive data).
+      description: Add any other context about the problem here (e.g., relevant API key settings without sensitive data, app configuration).
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/01_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/01_bug_report.yml
@@ -1,8 +1,8 @@
 name: Bug report
 description: Create a report to help us improve
 title: "[Bug]: "
-labels: ["bug"]
-projects: ["https://github.com/orgs/receptron/projects/3"] 
+labels: ["type: bug", "source: community"]
+projects: ["receptron/3"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/02_feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/02_feature_request.yml
@@ -1,0 +1,94 @@
+name: Feature request
+description: Suggest an idea for MulmoCast
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to suggest a new feature!
+
+  - type: checkboxes
+    id: pre-flight-checks
+    attributes:
+      label: Preliminary Checks
+      description: Before submitting, please make sure you have done the following.
+      options:
+        - label: I have searched the existing issues and have not found a similar feature request.
+          required: true
+
+  - type: textarea
+    id: problem-statement
+    attributes:
+      label: Is your feature request related to a problem? Please describe.
+      description: A clear and concise description of what the problem is.
+      placeholder: I'm always frustrated when...
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Describe the solution you'd like
+      description: A clear and concise description of what you want to happen.
+      placeholder: I would like to be able to...
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Describe alternatives you've considered
+      description: A clear and concise description of any alternative solutions or features you've considered.
+      placeholder: Other approaches that might work...
+    validations:
+      required: false
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: How important is this feature to you?
+      description: Help us understand the priority
+      options:
+        - Critical - blocking my work
+        - High - significant improvement to workflow
+        - Medium - nice to have
+        - Low - minor enhancement
+    validations:
+      required: true
+
+  - type: textarea
+    id: use-case
+    attributes:
+      label: Use Case
+      description: Describe your specific use case for this feature
+      placeholder: |
+        I need this feature for...
+        It would help me to...
+    validations:
+      required: true
+
+  - type: textarea
+    id: implementation
+    attributes:
+      label: Implementation suggestions
+      description: If you have ideas about how this could be implemented, please share them
+      placeholder: This could be implemented by...
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: contribution
+    attributes:
+      label: Contribution
+      description: Would you be willing to contribute to this feature?
+      options:
+        - label: I'm willing to submit a PR for this feature
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: Add any other context, mockups, or screenshots about the feature request here.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/02_feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/02_feature_request.yml
@@ -1,7 +1,7 @@
 name: Feature request
 description: Suggest an idea for MulmoCast
 title: "[Feature]: "
-labels: ["type: enhancement", "source: community"]
+labels: ["enhancement", "source: community"]
 projects: ["receptron/3"]
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/02_feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/02_feature_request.yml
@@ -1,8 +1,8 @@
 name: Feature request
 description: Suggest an idea for MulmoCast
 title: "[Feature]: "
-labels: ["enhancement"]
-projects: ["https://github.com/orgs/receptron/projects/3"] 
+labels: ["type: enhancement", "source: community"]
+projects: ["receptron/3"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/02_feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/02_feature_request.yml
@@ -2,6 +2,7 @@ name: Feature request
 description: Suggest an idea for MulmoCast
 title: "[Feature]: "
 labels: ["enhancement"]
+projects: ["https://github.com/orgs/receptron/projects/3"] 
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
CLI 側からGitHub Issues Templateをコピーし、アプリケーション向けに修正しました。

個人repo から試せます
https://github.com/ystknsh/mulmocast-app-yn/issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Introduced structured issue templates for bug reports and feature requests, guiding users with clear sections, placeholders, and examples for consistent, high-quality submissions.

* **Chores**
  * Bug report template includes required fields (description, reproduction, expected behavior, install method, app version, OS) plus optional attachments and error output.
  * Feature request template adds pre-flight check, problem/solution/use-case fields, priority selection, alternatives, implementation ideas, contribution intent, and additional context to streamline triage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->