### PR TITLE
Fix warning

### DIFF
--- a/src/renderer/pages/project/chat.vue
+++ b/src/renderer/pages/project/chat.vue
@@ -110,21 +110,21 @@
         </div>
       </div>
     </div>
+    <ConfirmDialog
+      :open="isClearChatDialogOpen"
+      dialogTitleKey="project.chat.confirmClear"
+      dialogDescriptionKey="ui.messages.cannotUndo"
+      confirmVariant="destructive"
+      confirmLabelKey="ui.actions.clearChat"
+      @update:open="(v) => (isClearChatDialogOpen = v)"
+      @confirm="
+        () => {
+          clearChat();
+          isClearChatDialogOpen = false;
+        }
+      "
+    />
   </div>
-  <ConfirmDialog
-    :open="isClearChatDialogOpen"
-    dialogTitleKey="project.chat.confirmClear"
-    dialogDescriptionKey="ui.messages.cannotUndo"
-    confirmVariant="destructive"
-    confirmLabelKey="ui.actions.clearChat"
-    @update:open="(v) => (isClearChatDialogOpen = v)"
-    @confirm="
-      () => {
-        clearChat();
-        isClearChatDialogOpen = false;
-      }
-    "
-  />
 </template>
 
 <script setup lang="ts">


### PR DESCRIPTION
ConfirmDialogをroot直下に置いたため、コンポーネントがFragmentになってしまい親から与えるclassの付与先が特定できずWarningが出ていた件の修正です。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the clear chat confirmation dialog placement within the chat page to prevent template/root conflicts that could block rendering.
  * Ensures the dialog opens, confirms, and closes reliably, with no change to the underlying clear-chat behavior.
  * Improves UI stability on the chat page by eliminating intermittent rendering errors related to the confirmation dialog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->