### PR TITLE
update docs

### DIFF
--- a/docs/how_to_use.md
+++ b/docs/how_to_use.md
@@ -129,10 +129,7 @@ AI機能を使用するために、各種サービス（画像/動画/音声生�
     - Markdown、Chart.js、Mermaid、HTML（Tailwind CSS）でスライドを作成します。
     - HTML プロンプト: スライド用 HTMLを生成します。
 
-    > **注**: スライドのテンプレート機能（Vision）は現在開発中です。JSONファイルでテンプレートを指定する方法については、[こちら](https://github.com/receptron/mulmocast-vision/tree/main/html/html) を参考にしてください。
-    > 例えば、`html/html/sectionDividerPage.html` を利用する場合、以下のように指定することで、定義済みのテンプレートに基づいたスライドが生成されます。
-
-    ![スライドテンプレート設定例](images/howtouse-slide-template-example.png)
+    > **Coming Soon**: スライドテンプレート機能（Vision）を開発中です。近日公開予定ですので、今しばらくお待ちください。
 
 - Style
   - 生成するコンテンツに関する設定です。


### PR DESCRIPTION
- Vision の手順を削除しました

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Replaced slide templating (Vision) guidance with a “Coming Soon” notice to reflect the feature’s in-progress status.
  * Removed previous JSON-based template configuration instructions, example usage, and reference image to avoid confusion.
  * Clarified that slide templating will be documented upon release; no functional changes were made.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->