### PR TITLE
Improve native video controls readability across backgrounds

### DIFF
--- a/src/renderer/components/mulmo_viewer/media_player.vue
+++ b/src/renderer/components/mulmo_viewer/media_player.vue
@@ -139,8 +139,13 @@ defineExpose({
 });
 </script>
 <style>
+video {
+  color-scheme: dark;
+  border-radius: 0;
+}
 video::-webkit-media-controls-enclosure {
-  background-color: transparent !important;
+  background-color: rgba(0, 0, 0, 0.5) !important;
+  border-radius: 0 !important;
 }
 
 video::-webkit-media-controls-current-time-display,
@@ -152,7 +157,7 @@ video::-webkit-media-controls-play-button,
 video::-webkit-media-controls-mute-button,
 video::-webkit-media-controls-overlay-play-button,
 video::-webkit-media-controls-fullscreen-button {
-  filter: invert(1) brightness(1.2);
+  filter: brightness(1.1);
 }
 
 video::-webkit-media-controls {


### PR DESCRIPTION
背景が白/黒どちらの場合でも、ネイティブの `<video>` コントロールが見やすくなるように調整しました。

### 変更内容
- color-scheme: dark を適用してコントロール全体の配色をダーク寄りに
- コントロール囲いに半透明の黒背景を付与（rgba(0,0,0,0.5)）
- アイコンを控えめに明るく（filter: brightness(1.1)）
- 動画本体とコントロールバーの角を四角に統一（border-radius: 0）

変更前

<img width="1422" height="160" alt="image" src="https://github.com/user-attachments/assets/eaff8bce-6edd-483b-a3f6-8219ecce7add" />


変更後

<img width="1106" height="283" alt="image" src="https://github.com/user-attachments/assets/50dc5123-4432-4054-86b8-b7a97120d67d" />

<img width="1076" height="194" alt="image" src="https://github.com/user-attachments/assets/ddcd6202-69c9-4124-927f-6743e9642c6f" />
