### PR TITLE
Add info message

### DIFF
--- a/src/renderer/i18n/en.ts
+++ b/src/renderer/i18n/en.ts
@@ -624,6 +624,7 @@ const lang = {
       moderation: "Moderation",
       moderationPlaceholder: "ex) low, auto",
       images: "Images",
+      imagesEmptyHint: "No images found. Please set references in the Ref tab.",
     },
     audioParams: {
       title: "Audio Parameters",

--- a/src/renderer/i18n/ja.ts
+++ b/src/renderer/i18n/ja.ts
@@ -625,6 +625,7 @@ const lang = {
       moderation: "モデレーション",
       moderationPlaceholder: "例) 低、自動",
       images: "画像",
+      imagesEmptyHint: "画像が見つかりません。参照タブで参考画像を設定してください。",
     },
     audioParams: {
       title: "オーディオ設定",

--- a/src/renderer/pages/project/script_editor/parameters/image_params.vue
+++ b/src/renderer/pages/project/script_editor/parameters/image_params.vue
@@ -72,6 +72,9 @@
       </div>
       <div v-if="images" class="my-2">
         <Label>{{ t("parameters.imageParams.images") }}</Label>
+        <div v-if="Object.keys(images).length === 0" class="text-muted-foreground mt-2 text-sm">
+          {{ t("parameters.imageParams.imagesEmptyHint") }}
+        </div>
         <div v-for="imageKey in Object.keys(images)" :key="imageKey">
           <Checkbox
             :model-value="(beat?.imageNames ?? Object.keys(images ?? {})).includes(imageKey)"


### PR DESCRIPTION
close: https://github.com/receptron/mulmocast-app/issues/756
refの設定がない場合に案内メッセージが表示されるように修正しました

<img width="617" height="144" alt="image" src="https://github.com/user-attachments/assets/e6dc5a6e-82b1-4ced-af72-9ed7dafff429" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Image Parameters now shows a contextual hint when no images are available, guiding you to add reference images in the Ref tab. The message appears only when the images list is empty, improving clarity and onboarding.

- Localization
  - Added translations for the new no-images hint in English and Japanese to ensure a consistent experience across supported languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->