### PR TITLE
feat: update i18n translations

### DIFF
--- a/src/renderer/i18n/en.ts
+++ b/src/renderer/i18n/en.ts
@@ -623,7 +623,7 @@ const lang = {
       stylePlaceholder: "ex) vivid, natural",
       moderation: "Moderation",
       moderationPlaceholder: "ex) low, auto",
-      images: "Images",
+      images: "Reference Image",
       imagesEmptyHint: "No images found. Please set references in the Ref tab.",
     },
     audioParams: {

--- a/src/renderer/i18n/ja.ts
+++ b/src/renderer/i18n/ja.ts
@@ -624,7 +624,7 @@ const lang = {
       stylePlaceholder: "例) 鮮やか、自然",
       moderation: "モデレーション",
       moderationPlaceholder: "例) 低、自動",
-      images: "画像",
+      images: "参考画像",
       imagesEmptyHint: "画像が見つかりません。参照タブで参考画像を設定してください。",
     },
     audioParams: {


### PR DESCRIPTION
images から reference image へ変更しました。

<img width="482" height="279" alt="CleanShot 2025-09-15 at 14 38 24" src="https://github.com/user-attachments/assets/8bbd8596-3862-457f-8cf9-607760a20de1" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the image parameter label in the UI from “Images” to “Reference Image” to improve clarity.
  * Refined Japanese localization: changed 画像 to 参考画像 for the same label to match the intended meaning.
  * These wording updates appear wherever the image parameter is displayed (e.g., forms and settings) and align terminology across languages.
  * No functional changes; this is a text/translation polish only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->