### PR TITLE
Fix image preview

### DIFF
--- a/src/main/mulmo/handler_contents.ts
+++ b/src/main/mulmo/handler_contents.ts
@@ -1,7 +1,6 @@
 import {
   getBeatAudioPath,
   MulmoPresentationStyleMethods,
-  MulmoStudioContextMethods,
   MulmoMediaSourceMethods,
   imagePreprocessAgent,
   getReferenceImagePath,
@@ -11,6 +10,7 @@ import {
   beatId,
   listLocalizedAudioPaths,
   defaultBGMPath,
+  resolveAssetPath,
   type MulmoStudioContext,
   type MulmoStudioMultiLingual,
 } from "mulmocast";
@@ -151,7 +151,7 @@ export const mulmoReferenceImagesFiles = async (projectId: string) => {
             if (image.type === "imagePrompt") {
               return getReferenceImagePath(context, key, "png");
             } else if (image.type === "image" && image.source.kind === "path") {
-              return MulmoStudioContextMethods.resolveAssetPath(context, image.source.path);
+              return resolveAssetPath(context, image.source.path);
             }
           })();
           if (path && fs.existsSync(path)) {
@@ -185,7 +185,7 @@ export const mulmoReferenceImagesFile = async (projectId: string, key: string) =
       if (image.type === "imagePrompt") {
         return getReferenceImagePath(context, key, "png");
       } else if (image.type === "image" && image.source.kind === "path") {
-        return MulmoStudioContextMethods.resolveAssetPath(context, image.source.path);
+        return resolveAssetPath(context, image.source.path);
       }
     })();
     if (path && fs.existsSync(path)) {

--- a/src/renderer/pages/project/script_editor/reference.vue
+++ b/src/renderer/pages/project/script_editor/reference.vue
@@ -86,7 +86,7 @@
 
 <script setup lang="ts">
 import { Trash, Sparkles, FileImage, Loader2 } from "lucide-vue-next";
-import { ref, computed } from "vue";
+import { ref, computed, nextTick } from "vue";
 import { useI18n } from "vue-i18n";
 
 import type { MulmoImageMedia, MulmoImagePromptMedia, MulmoImageParamsImages } from "mulmocast";
@@ -220,7 +220,7 @@ const handleDrop = (event: DragEvent, imageKey: string) => {
       );
       emit("updateImagePath", imageKey, "./" + path);
       // Workaround: wait for the script change
-      await new Promise((resolve) => setTimeout(resolve, 0));
+      await nextTick();
       const res = await window.electronAPI.mulmoHandler("mulmoReferenceImagesFile", props.projectId, imageKey);
       imageRefs.value[imageKey] = res ? bufferToUrl(res, "image/png") : null;
     };

--- a/src/renderer/pages/project/script_editor/reference.vue
+++ b/src/renderer/pages/project/script_editor/reference.vue
@@ -219,6 +219,8 @@ const handleDrop = (event: DragEvent, imageKey: string) => {
         extension,
       );
       emit("updateImagePath", imageKey, "./" + path);
+      // Workaround: wait for the script change
+      await new Promise((resolve) => setTimeout(resolve, 0));
       const res = await window.electronAPI.mulmoHandler("mulmoReferenceImagesFile", props.projectId, imageKey);
       imageRefs.value[imageKey] = res ? bufferToUrl(res, "image/png") : null;
     };


### PR DESCRIPTION
RefのMedia FileでDrop時の画像プレビューが表示されない問題の修正です。

close: #793 


## Before

https://github.com/user-attachments/assets/11ad1bce-260b-460d-b778-0372a87bddb0


## After

https://github.com/user-attachments/assets/be8dc564-457f-4848-a5c1-7baa2a17474e



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved drag-and-drop reliability for reference images so updates apply consistently and avoid missing or stale images.

* **Refactor**
  * Internal asset path resolution updated; no changes to user-facing behavior or public APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->