### PR TITLE
add dummy player

### DIFF
--- a/src/renderer/components/mulmo_viewer/media_player_dummy.vue
+++ b/src/renderer/components/mulmo_viewer/media_player_dummy.vue
@@ -1,0 +1,42 @@
+<template>
+  <div>
+    <div v-if="videoWithAudioSource">
+      <video
+        :src="videoWithAudioSource"
+        class="mx-auto h-auto max-h-[80vh] w-auto object-contain"
+        :controls="controlsEnabled"
+        ref="videoWithAudioRef"
+      />
+    </div>
+    <div v-else-if="videoSource" class="relative inline-block">
+      <video
+        class="mx-auto h-auto max-h-[80vh] w-auto object-contain"
+        :src="videoSource"
+        ref="videoRef"
+        :controls="controlsEnabled"
+      />
+      <audio :src="audioSource" ref="audioSyncRef" v-if="audioSource" @ended="handleAudioEnd" />
+    </div>
+    <div v-else-if="audioSource">
+      <video
+        class="mx-auto h-auto max-h-[80vh] w-auto object-contain"
+        :src="audioSource"
+        :poster="imageSource ?? mulmoImage"
+        :controls="controlsEnabled"
+        ref="audioRef"
+      />
+    </div>
+    <div v-else-if="imageSource" class="relative inline-block">
+      <img :src="imageSource" ref="imageRef" class="mx-auto h-auto max-h-[80vh] w-auto object-contain" />
+    </div>
+  </div>
+</template>
+<script setup lang="ts">
+interface Props {
+  videoWithAudioSource?: string;
+  videoSource?: string;
+  imageSource?: string;
+  audioSource?: string;
+}
+const props = defineProps<Props>();
+</script>

--- a/src/renderer/components/mulmo_viewer/media_player_dummy.vue
+++ b/src/renderer/components/mulmo_viewer/media_player_dummy.vue
@@ -1,33 +1,21 @@
 <template>
   <div>
     <div v-if="videoWithAudioSource">
-      <video
-        :src="videoWithAudioSource"
-        class="mx-auto h-auto max-h-[80vh] w-auto object-contain"
-        :controls="controlsEnabled"
-        ref="videoWithAudioRef"
-      />
+      <video :src="videoWithAudioSource" class="mx-auto h-auto max-h-[80vh] w-auto object-contain" />
     </div>
     <div v-else-if="videoSource" class="relative inline-block">
-      <video
-        class="mx-auto h-auto max-h-[80vh] w-auto object-contain"
-        :src="videoSource"
-        ref="videoRef"
-        :controls="controlsEnabled"
-      />
-      <audio :src="audioSource" ref="audioSyncRef" v-if="audioSource" @ended="handleAudioEnd" />
+      <video class="mx-auto h-auto max-h-[80vh] w-auto object-contain" :src="videoSource" />
+      <audio :src="audioSource" v-if="audioSource" />
     </div>
     <div v-else-if="audioSource">
       <video
         class="mx-auto h-auto max-h-[80vh] w-auto object-contain"
         :src="audioSource"
         :poster="imageSource ?? mulmoImage"
-        :controls="controlsEnabled"
-        ref="audioRef"
       />
     </div>
     <div v-else-if="imageSource" class="relative inline-block">
-      <img :src="imageSource" ref="imageRef" class="mx-auto h-auto max-h-[80vh] w-auto object-contain" />
+      <img :src="imageSource" class="mx-auto h-auto max-h-[80vh] w-auto object-contain" />
     </div>
   </div>
 </template>

--- a/src/renderer/components/mulmo_viewer/media_player_dummy.vue
+++ b/src/renderer/components/mulmo_viewer/media_player_dummy.vue
@@ -26,5 +26,5 @@ interface Props {
   imageSource?: string;
   audioSource?: string;
 }
-const props = defineProps<Props>();
+defineProps<Props>();
 </script>

--- a/src/renderer/components/mulmo_viewer/mulmo_viewer.vue
+++ b/src/renderer/components/mulmo_viewer/mulmo_viewer.vue
@@ -6,7 +6,7 @@
       <p class="text-muted-foreground mb-4 text-sm">{{ t("project.productTabs.slide.description") }}</p>
     </div>
     <div v-else>
-      <div class="flex w-full items-center justify-between">
+      <div class="flex w-full items-center justify-between" ref="boxRef" :style="{ height: boxHeight + 'px' }">
         <Button
           @click="decrease"
           variant="ghost"
@@ -85,7 +85,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, watch, computed } from "vue";
+import { ref, watch, computed, onMounted, onBeforeUnmount } from "vue";
 import { useI18n } from "vue-i18n";
 import { FileImage, ChevronLeft, ChevronRight } from "lucide-vue-next";
 import { type MultiLingualTexts, beatId } from "mulmocast/browser";
@@ -121,6 +121,26 @@ const bgmRef = ref();
 const currentPage = ref(0);
 const audioRef = ref();
 const autoPlay = ref(true);
+
+const boxRef = ref(null);
+const boxHeight = ref(0);
+const ratio = 0.5625; // 16:9（height = width * 9/16）
+
+function updateHeight() {
+  if (boxRef.value) {
+    const width = boxRef.value.offsetWidth;
+    boxHeight.value = width * ratio;
+  }
+}
+
+onMounted(() => {
+  updateHeight();
+  window.addEventListener("resize", updateHeight);
+});
+
+onBeforeUnmount(() => {
+  window.removeEventListener("resize", updateHeight);
+});
 
 const isPlaying = ref(false);
 

--- a/src/renderer/components/mulmo_viewer/mulmo_viewer.vue
+++ b/src/renderer/components/mulmo_viewer/mulmo_viewer.vue
@@ -36,24 +36,16 @@
           <ChevronRight class="h-4 w-4" />
         </Button>
       </div>
-      <div class="flex w-full items-center justify-between" v-if="false">
-        <Button
-          @click="decrease"
-          variant="ghost"
-          :disabled="currentPage === 0"
-          :class="{ 'opacity-0!': currentPage === 0 }"
-        >
-          <ChevronLeft class="h-4 w-4" />
-        </Button>
-        <Button
-          @click="increase"
-          variant="ghost"
-          :disabled="currentPage === beats.length - 1"
-          :class="{ 'opacity-0!': currentPage === beats.length - 1 }"
-        >
-          <ChevronRight class="h-4 w-4" />
-        </Button>
-      </div>
+
+      <MediaPlayerDummy
+        v-if="nextBeat"
+        :videoWithAudioSource="lipSyncFiles?.[nextBeat?.id]"
+        :videoSource="movieFiles?.[nextBeat?.id]"
+        :imageSource="imageFiles?.[nextBeat?.id]"
+        :audioSource="audioFiles[currentLanguage]?.[nextBeat?.id]"
+        class="hidden"
+      />
+
       <!-- text section -->
       <div class="bg-foreground/5 mt-2 rounded-lg p-2 text-sm">
         {{
@@ -103,6 +95,7 @@ import { bufferToUrl } from "@/lib/utils";
 import { Button, Checkbox } from "@/components/ui";
 
 import MediaPlayer from "./media_player.vue";
+import MediaPlayerDummy from "./media_player_dummy.vue";
 
 import { useImageFiles, useAudioFiles } from "@/pages/composable";
 import { useMulmoEventStore, useMulmoGlobalStore } from "@/store";
@@ -186,6 +179,11 @@ const beats = computed(() => {
 const currentBeat = computed(() => {
   return beats.value[currentPage.value];
 });
+
+const nextBeat = computed(() => {
+  return beats.value[currentPage.value + 1];
+});
+
 const currentBeatId = computed(() => {
   return beatId(currentBeat.value?.id, currentPage.value);
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a hidden preloader component that preloads the next beat’s media to reduce wait times and enable smoother transitions.
  * New media preloader supports video-with-audio, separate video+audio, audio-only (with poster), and images.
  * Preloading remains invisible and preserves current UI and playback flow.
  * Container height now adapts responsively to maintain layout during preloading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->