### PR TITLE
Fix alert

### DIFF
--- a/src/renderer/lib/notification.ts
+++ b/src/renderer/lib/notification.ts
@@ -7,9 +7,17 @@ export const notifySuccess = (message: string, description?: string) => {
   });
 };
 
-export const notifyError = (message: string, description?: string) => {
+export const notifyError = (
+  message: string,
+  description?: string,
+  action?: {
+    label: string;
+    onClick: () => void;
+  },
+) => {
   toast.error(message, {
     description,
+    action,
   });
 };
 

--- a/src/renderer/pages/project/script_editor/beat_editor.vue
+++ b/src/renderer/pages/project/script_editor/beat_editor.vue
@@ -261,6 +261,7 @@ import Chart from "./beat_editors/chart.vue";
 import Media from "./beat_editors/media.vue";
 import Mermaid from "./beat_editors/mermaid.vue";
 import Vision from "./beat_editors/vision.vue";
+import { notifyError } from "@/lib/notification";
 
 type FileData = ArrayBuffer | string | null;
 
@@ -338,7 +339,10 @@ const changeBeat = (beat: MulmoBeat) => {
 const generateImageOnlyImage = () => {
   const imageAgentInfo = MulmoPresentationStyleMethods.getImageAgentInfo(props.mulmoScript, props.beat);
   if (!globalStore?.hasApiKey(imageAgentInfo.keyName)) {
-    alert("You need setup " + imageAgentInfo.keyName);
+    notifyError("Error", "You need setup " + imageAgentInfo.keyName, {
+      label: "Setup",
+      onClick: () => globalStore.toggleSettingModal(),
+    });
     return;
   }
   emit("generateImage", props.index, "image");
@@ -346,7 +350,10 @@ const generateImageOnlyImage = () => {
 const generateImageOnlyMovie = () => {
   const imageAgentInfo = MulmoPresentationStyleMethods.getMovieAgentInfo(props.mulmoScript, props.beat);
   if (!globalStore?.hasApiKey(imageAgentInfo.keyName)) {
-    alert("You need setup " + imageAgentInfo.keyName);
+    notifyError("Error", "You need setup " + imageAgentInfo.keyName, {
+      label: "Setup",
+      onClick: () => globalStore.toggleSettingModal(),
+    });
     return;
   }
   emit("generateImage", props.index, "movie");
@@ -355,7 +362,10 @@ const generateImageOnlyMovie = () => {
 const generateLipSyncMovie = async () => {
   const lipSyncAgentInfo = MulmoPresentationStyleMethods.getLipSyncAgentInfo(props.mulmoScript, props.beat);
   if (!globalStore?.hasApiKey(lipSyncAgentInfo.keyName)) {
-    alert("You need setup " + lipSyncAgentInfo.keyName);
+    notifyError("Error", "You need setup " + lipSyncAgentInfo.keyName, {
+      label: "Setup",
+      onClick: () => globalStore.toggleSettingModal(),
+    });
     return;
   }
   await window.electronAPI.mulmoHandler("mulmoGenerateBeatAudio", projectId.value, props.index);


### PR DESCRIPTION
API Key Errorのアラートの表示をブラウザのnativeから、共通のnotificationに変更しました。
また、ボタンを押すことでsettingsが開く様に変更しました。

https://github.com/user-attachments/assets/e3486d54-8663-49ef-afb4-c890822741ad





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Error notifications now support an optional action button with custom label and click handler, enabling quick follow-up actions from the toast.

* **Refactor**
  * Replaced blocking alert dialogs with non-blocking error notifications in the script editor’s beat editor for cases of missing API keys.
  * Adds a “Setup” action in these notifications to open settings, improving flow for:
    - Image generation (image-only)
    - Movie generation (image-only)
    - Lip-sync movie generation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->