### PR TITLE
i18n ja on Script Editor Tab

### DIFF
--- a/src/renderer/i18n/ja.ts
+++ b/src/renderer/i18n/ja.ts
@@ -379,8 +379,8 @@ const lang = {
     },
     scriptEditor: {
       text: {
-        tabLabel: "Text",
-        mode: "Text モード",
+        tabLabel: "テキスト",
+        mode: "テキストモード",
         modeDescription: "話者と会話や字幕へ編集ができます",
       },
       yaml: {
@@ -394,13 +394,13 @@ const lang = {
         modeDescription: "MulmoScript を直接編集します",
       },
       media: {
-        tabLabel: "Media",
-        mode: "Media モード",
+        tabLabel: "メディア",
+        mode: "メディアモード",
         modeDescription: "Beatごとの画像/動画の編集とプレビュー",
       },
       style: {
-        tabLabel: "Style",
-        mode: "Style",
+        tabLabel: "スタイル",
+        mode: "スタイル",
         modeDescription: "音声/動画/画像/字幕などの設定",
       },
       reference: {


### PR DESCRIPTION
Slack で投稿された件の対応です。

Slack
<img width="368" height="147" alt="image" src="https://github.com/user-attachments/assets/7227134e-f9c2-489a-8766-89dd099394c0" />


対応後
<img width="659" height="319" alt="image" src="https://github.com/user-attachments/assets/4738ff53-000e-479c-b7f1-16763ba9e8c4" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Improved Japanese localization for the Script Editor. Updated tab labels and mode names for Text, Media, and Style to their Japanese equivalents (テキスト, メディア, スタイル).
  * Both tab titles and mode indicators now display in Japanese, aligning with the rest of the interface and enhancing clarity for Japanese users.
  * Increases consistency of terminology across the editor within the Japanese locale.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->