### PR TITLE
Ensure packaged app resolves mulmocast-vision templates

### DIFF
--- a/src/main/mulmo/handler_common.ts
+++ b/src/main/mulmo/handler_common.ts
@@ -1,7 +1,12 @@
 import { initializeContextFromFiles, getFileObject, setGraphAILogger, type MulmoStudioContext } from "mulmocast";
 import { getProjectPath, SCRIPT_FILE_NAME } from "../project_manager";
 import path from "path";
-import { WebContents } from "electron";
+import { WebContents, app } from "electron";
+
+const isDev = !app.isPackaged;
+const nodeModuleRootPath = isDev
+  ? path.resolve(__dirname, "../../node_modules")
+  : path.join(process.resourcesPath, "app.asar", ".vite", "build", "node_modules");
 
 export const getContext = async (projectId: string, targetLang?: string): Promise<MulmoStudioContext | null> => {
   const projectPath = getProjectPath(projectId);
@@ -13,7 +18,7 @@ export const getContext = async (projectId: string, targetLang?: string): Promis
     // audiodir: argv.a,
     // presentationStyle: argv.p,
     file: SCRIPT_FILE_NAME,
-    nodeModuleRootPath: path.resolve(__dirname, "../../node_modules"),
+    nodeModuleRootPath,
   });
   setGraphAILogger(true, {});
 

--- a/vite.main.config.ts
+++ b/vite.main.config.ts
@@ -4,7 +4,7 @@ import fs from "fs";
 import ffmpegFfprobeStatic from "ffmpeg-ffprobe-static";
 
 // Packages to exclude from bundle and load directly from node_modules
-const external_packages = ["jsdom", "puppeteer", "puppeteer-core"];
+const external_packages = ["jsdom", "mulmocast-vision", "puppeteer", "puppeteer-core"];
 
 const isDev = process.env.NODE_ENV === "development";
 


### PR DESCRIPTION
## 問題事項
Application で vision 生成しようとするとエラーが発生し、生成できない。
mulmo visionのtemplateのpath問題
<img width="387" height="171" alt="image" src="https://github.com/user-attachments/assets/d92b32e9-0b53-4e3c-a846-4de91a917455" />


## 変更内容
- Vite のメインバンドルで mulmocast-vision を external 指定し、HTML テンプレート群をそのまま node_modules レイアウトで保持できるようにしました。

- handler_common.ts の nodeModuleRootPath を開発時とパッケージ時で出し分け、app.asar/.vite/build/node_modules 配下からテンプレート資産を解決できるようにしました。
