### PR TITLE
Add api key modal

### DIFF
--- a/src/renderer/app.vue
+++ b/src/renderer/app.vue
@@ -5,6 +5,7 @@
     <SettingModal />
     <ViewerModal />
     <OnboardingModal :is-open="globalStore.isOpenOnboardingModal" @complete="globalStore.toggleOnboardingModal" />
+    <ApiKeyModal />
   </div>
 </template>
 
@@ -15,6 +16,7 @@ import { Toaster } from "@/components/ui/sonner";
 import SettingModal from "@/components/setting_modal.vue";
 import ViewerModal from "@/components/mulmo_viewer_modal.vue";
 import OnboardingModal from "@/components/onboarding_modal.vue";
+import ApiKeyModal from "@/components/api_key_modal.vue";
 import { useTheme } from "@/composables/use_theme";
 
 import "vue-sonner/style.css";
@@ -29,6 +31,7 @@ export default defineComponent({
     SettingModal,
     ViewerModal,
     OnboardingModal,
+    ApiKeyModal,
   },
   setup() {
     const mulmoEventStore = useMulmoEventStore();

--- a/src/renderer/components/api_key_modal.vue
+++ b/src/renderer/components/api_key_modal.vue
@@ -1,0 +1,144 @@
+<template>
+  <Dialog :open="modalStore.isOpenApiKeyModal" @update:open="onUpdateOpen">
+    <DialogContent class="flex max-w-lg flex-col" :hide-close="isSaving">
+      <DialogHeader class="flex-shrink-0">
+        <DialogTitle class="text-center text-2xl font-bold">
+          {{ t("settings.apiKeys.title") }}
+        </DialogTitle>
+        <DialogDescription class="text-muted-foreground text-center">
+          {{ t("settings.apiKeys.description") }}
+        </DialogDescription>
+      </DialogHeader>
+
+      <div class="flex-1 space-y-6 overflow-y-auto p-1">
+        <Card v-if="targetKey">
+          <CardContent>
+            <ApiKeyInput
+              v-if="targetKey"
+              :key="targetKey"
+              :env-key="targetKey"
+              :config="ENV_KEYS[targetKey]"
+              :api-key="apiKey"
+              :show-key="showKey"
+              @update:api-key="(value) => (apiKey = value)"
+              @update:show-key="(value) => (showKey = value)"
+            />
+          </CardContent>
+        </Card>
+
+        <div
+          v-if="errorMessage"
+          class="flex items-center gap-2 rounded-lg border border-red-200 bg-red-50 p-3 text-red-700 dark:border-red-800/30 dark:bg-red-950/20 dark:text-red-400"
+        >
+          <AlertCircle class="h-4 w-4 flex-shrink-0" />
+          <span class="text-sm">{{ errorMessage }}</span>
+        </div>
+      </div>
+
+      <DialogFooter class="flex flex-shrink-0 justify-between border-t pt-4">
+        <Button variant="outline" :disabled="isSaving" @click="handleCancel">
+          {{ t("ui.actions.cancel") }}
+        </Button>
+        <Button :disabled="!canSave || isSaving" @click="handleSave">
+          <Loader2 v-if="isSaving" class="mr-2 h-4 w-4 animate-spin" />
+          {{ t("ui.actions.update") }}
+        </Button>
+      </DialogFooter>
+    </DialogContent>
+  </Dialog>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, watch } from "vue";
+import { useI18n } from "vue-i18n";
+import { Loader2, AlertCircle } from "lucide-vue-next";
+
+import { Button } from "@/components/ui";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Card, CardContent } from "@/components/ui/card";
+import ApiKeyInput from "@/components/api_key_input.vue";
+
+import { notifySuccess, notifyError } from "@/lib/notification";
+import { ENV_KEYS } from "../../shared/constants";
+import { useMulmoGlobalStore, useModalStore } from "@/store";
+
+const { t } = useI18n();
+const globalStore = useMulmoGlobalStore();
+const modalStore = useModalStore();
+
+const isSaving = ref(false);
+const errorMessage = ref("");
+const apiKey = ref("");
+const showKey = ref(false);
+
+const targetKey = computed(() => modalStore.apiKeyModalTarget);
+
+watch(
+  () => targetKey.value,
+  async (newKey) => {
+    errorMessage.value = "";
+    showKey.value = false;
+    apiKey.value = "";
+    if (!newKey) return;
+    try {
+      const settings = await window.electronAPI.settings.get();
+      apiKey.value = settings[newKey] ?? settings.APIKEY?.[newKey] ?? "";
+    } catch (e) {
+      console.error(e);
+    }
+  },
+  { immediate: true },
+);
+
+const canSave = computed(() => {
+  return !!apiKey.value.trim();
+});
+
+const handleCancel = () => {
+  modalStore.hideApiKeyModal();
+};
+
+const handleSave = async () => {
+  if (!targetKey.value) return;
+  if (!canSave.value) {
+    errorMessage.value = t("onboarding.errors.requiredApiKey");
+    return;
+  }
+
+  isSaving.value = true;
+  errorMessage.value = "";
+
+  try {
+    const settings = await window.electronAPI.settings.get();
+    const newSettings = {
+      ...settings,
+      [targetKey.value]: apiKey.value,
+      APIKEY: {
+        ...(settings.APIKEY ?? {}),
+        [targetKey.value]: apiKey.value,
+      },
+    } as const;
+    await window.electronAPI.settings.set(newSettings);
+    globalStore.updateSettings(newSettings);
+    notifySuccess(t("settings.notifications.success"));
+    modalStore.hideApiKeyModal();
+  } catch (error) {
+    console.error("Failed to save api key:", error);
+    errorMessage.value = t("onboarding.errors.saveFailed");
+    notifyError(t("ui.status.error"), t("onboarding.errors.saveFailed"));
+  } finally {
+    isSaving.value = false;
+  }
+};
+
+const onUpdateOpen = (open: boolean) => {
+  if (!open) handleCancel();
+};
+</script>

--- a/src/renderer/composables/notify.ts
+++ b/src/renderer/composables/notify.ts
@@ -2,16 +2,17 @@ import { notifyError } from "@/lib/notification";
 import { useI18n } from "vue-i18n";
 import { ENV_KEYS } from "../../shared/constants";
 
-import { useMulmoGlobalStore } from "@/store";
+import { useModalStore, useMulmoGlobalStore } from "@/store";
 
 export const useApiErrorNotify = () => {
+  const modalStore = useModalStore();
   const globalStore = useMulmoGlobalStore();
   const { t } = useI18n();
 
   const apiErrorNotify = (keyName: keyof typeof ENV_KEYS) => {
     notifyError(t("ui.status.error"), t("notify.apiKey.error", { keyName: ENV_KEYS[keyName].title }), {
       label: t("notify.apiKey.setup"),
-      onClick: () => globalStore.toggleSettingModal(),
+      onClick: () => modalStore.showApiKeyModal(keyName),
     });
   };
 

--- a/src/renderer/store/index.ts
+++ b/src/renderer/store/index.ts
@@ -3,3 +3,4 @@ export { useMulmoScriptHistoryStore } from "./mulmo_script_history";
 export { useGraphAIDebugLogStore } from "./graphai_debug_log";
 export { useZodErrorStore } from "./zod_error";
 export { useMulmoGlobalStore } from "./global";
+export { useModalStore } from "./modal";

--- a/src/renderer/store/modal.ts
+++ b/src/renderer/store/modal.ts
@@ -1,0 +1,25 @@
+import { ref } from "vue";
+import { defineStore } from "pinia";
+import { ENV_KEYS } from "../../shared/constants";
+
+export const useModalStore = defineStore("modal", () => {
+  const isOpenApiKeyModal = ref(false);
+  const apiKeyModalTarget = ref<keyof typeof ENV_KEYS | null>(null);
+
+  const showApiKeyModal = (keyName: keyof typeof ENV_KEYS) => {
+    apiKeyModalTarget.value = keyName;
+    isOpenApiKeyModal.value = true;
+  };
+
+  const hideApiKeyModal = () => {
+    isOpenApiKeyModal.value = false;
+    apiKeyModalTarget.value = null;
+  };
+
+  return {
+    isOpenApiKeyModal,
+    apiKeyModalTarget,
+    showApiKeyModal,
+    hideApiKeyModal,
+  };
+});


### PR DESCRIPTION
API Key Errorの際にAPI Keyを直感的に設定できるようにAPI Keyの設定専用のモーダルを追加しました。


https://github.com/user-attachments/assets/ed8cf37e-61e5-4682-9b47-64a3f0339b49




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added an API Key modal to manage service keys directly in the app.
  - View existing keys, edit with visibility toggle, validation, and loading state during save.
  - Clear success and error notifications, with localized messages.
  - Opens automatically from relevant error notifications to guide setup.
  - Cancel and Update actions for safe changes; settings persist after successful updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->