### PR TITLE
Use build date for Forge buildVersion

### DIFF
--- a/forge.config.ts
+++ b/forge.config.ts
@@ -9,11 +9,12 @@ import { FuseV1Options, FuseVersion } from "@electron/fuses";
 
 import { execSync } from "child_process";
 const gitCommit = execSync("git rev-parse --short HEAD").toString().trim();
-const buildTime = new Date().toISOString().slice(0, 10).replace(/[-:T]/g, "");
+const now = new Date();
+const buildDate = now.toISOString().slice(0, 10).replace(/-/g, "");
 
 const config: ForgeConfig = {
   packagerConfig: {
-    buildVersion: `${buildTime}.${gitCommit}`,
+    buildVersion: buildDate,
     // Enable ASAR and unpack Puppeteer's Chromium binaries so they can be executed at runtime
     asar: {
       unpack: "**/node_modules/puppeteer/.local-chromium/**",


### PR DESCRIPTION
- Electron Forge の buildVersion をビルド日 (YYYYMMDD) のみに変更しました。


<img width="278" height="142" alt="image" src="https://github.com/user-attachments/assets/327376d9-dacd-41f6-8e6a-a0b6fbf43667" />


## 理由
- Windows のインストーラは buildVersion が整数パターンでないと落ちるため
- commit hash 値だとアルファベットが含まれるため
