### PR TITLE
Add 2-column layout support for beginner mode and fix column state transitions

### DIFF
--- a/src/renderer/pages/project/composable/style.ts
+++ b/src/renderer/pages/project/composable/style.ts
@@ -1,4 +1,5 @@
 import { ref, computed } from "vue";
+import { useMulmoGlobalStore } from "@/store";
 
 // Column open/close states
 export const isLeftColumnOpen = ref(true); // Default: open
@@ -6,6 +7,17 @@ export const isRightColumnOpen = ref(true); // Default: open
 
 // Computed grid layout class based on column states
 export const gridLayoutClass = computed(() => {
+  const globalStore = useMulmoGlobalStore();
+
+  // 2-column layout for beginners (no AI chat column)
+  if (!globalStore.userIsSemiProOrAbove) {
+    if (isRightColumnOpen.value) {
+      return "lg:grid-cols-[1fr_30%]";
+    }
+    return "lg:grid-cols-[1fr_48px]";
+  }
+
+  // 3-column layout for semi-pro and above
   if (isLeftColumnOpen.value && isRightColumnOpen.value) {
     return "lg:grid-cols-[30%_40%_1fr]";
   } else if (isLeftColumnOpen.value) {

--- a/src/renderer/pages/project/composable/style.ts
+++ b/src/renderer/pages/project/composable/style.ts
@@ -1,9 +1,21 @@
-import { ref, computed } from "vue";
+import { ref, computed, watch } from "vue";
 import { useMulmoGlobalStore } from "@/store";
 
 // Column open/close states
 export const isLeftColumnOpen = ref(true); // Default: open
 export const isRightColumnOpen = ref(true); // Default: open
+
+// Watch for user level changes and reset left column state for beginners
+const globalStore = useMulmoGlobalStore();
+watch(
+  () => globalStore.userIsSemiProOrAbove,
+  (newValue) => {
+    // When switching to beginner mode, ensure left column is "open" for proper layout
+    if (!newValue) {
+      isLeftColumnOpen.value = true;
+    }
+  }
+);
 
 // Computed grid layout class based on column states
 export const gridLayoutClass = computed(() => {
@@ -11,6 +23,8 @@ export const gridLayoutClass = computed(() => {
 
   // 2-column layout for beginners (no AI chat column)
   if (!globalStore.userIsSemiProOrAbove) {
+    // In beginner mode, force left column to be considered "open" since it doesn't exist
+    // Only right column state matters
     if (isRightColumnOpen.value) {
       return "lg:grid-cols-[1fr_30%]";
     }

--- a/src/renderer/pages/project/composable/style.ts
+++ b/src/renderer/pages/project/composable/style.ts
@@ -14,7 +14,7 @@ watch(
     if (!newValue) {
       isLeftColumnOpen.value = true;
     }
-  }
+  },
 );
 
 // Computed grid layout class based on column states


### PR DESCRIPTION
## 概要
初心者モード用の2列レイアウトサポートを追加し、ユーザーレベル切り替え時の列状態の問題を修正しました。

## 変更内容
  1. 2列レイアウトの実装
  - 初心者モード（!globalStore.userIsSemiProOrAbove）の場合に2列レイアウトを使用
  - AIチャット列（左列）を非表示にし、中央列と右列のみを表示
  - 右列の開閉状態に応じて適切なグリッドレイアウトを計算

  2. 列状態遷移の修正
 - 左列が閉じた状態で初心者モードに切り替わった際の表示問題を修正
  - ユーザーレベル変更を監視するウォッチャーを追加
  - 初心者モードへの切り替え時に左列状態を自動的にリセット