### PR TITLE
Update beat editor text input to textarea and improve audio controls  layout

### DIFF
--- a/src/renderer/pages/project/script_editor/beat_editor.vue
+++ b/src/renderer/pages/project/script_editor/beat_editor.vue
@@ -31,19 +31,24 @@
             language: t('languages.' + lang),
           })
         "
-        class="min-h-8 resize-y mb-2"
+        class="mb-2 min-h-8 resize-y"
         :class="isBeginner && !beat.text ? 'border-2 border-red-600' : ''"
         rows="2"
       />
       <div class="flex items-center gap-2">
-        <Button variant="outline" size="sm" @click="generateAudio()" class="w-fit" :disabled="beat?.text?.length === 0">{{
-          t("ui.actions.generateAudio")
-        }}</Button>
+        <Button
+          variant="outline"
+          size="sm"
+          @click="generateAudio()"
+          class="w-fit"
+          :disabled="beat?.text?.length === 0"
+          >{{ t("ui.actions.generateAudio") }}</Button
+        >
         <audio
           :src="audioFile"
           v-if="!!audioFile"
           controlslist="nodownload noplaybackrate noremoteplayback"
-          class="flex-1 h-7"
+          class="h-7 flex-1"
           controls
         />
       </div>


### PR DESCRIPTION
beat タブ
- テキスト → テキストエリアへ
- 音声生成、プレイヤーを翻訳タブに合わせて2段へ
- プレイヤーを横幅いっぱいへ
変更しました

<img width="608" height="385" alt="image" src="https://github.com/user-attachments/assets/fa520980-3f32-45db-94b7-11325aa76616" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Multiline, resizable editor for beat text replaces the single-line input, improving readability and editing comfort.
  - Inline grouping of Generate Audio and the audio player for a streamlined, compact workflow.

- Style
  - Refined layout and spacing: container adjustments, default 2 rows with minimum height for the editor, and improved margins.
  - Audio player now flexibly expands to available space with responsive width/height while retaining controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->