### PR TITLE
reset speaker data when provider change

### DIFF
--- a/src/renderer/pages/project/script_editor/styles/speech_params.vue
+++ b/src/renderer/pages/project/script_editor/styles/speech_params.vue
@@ -170,7 +170,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, nextTick } from "vue";
+import { ref, computed } from "vue";
 import { Card, Button, Label, Input } from "@/components/ui";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import MulmoError from "./mulmo_error.vue";

--- a/src/renderer/pages/project/script_editor/styles/speech_params.vue
+++ b/src/renderer/pages/project/script_editor/styles/speech_params.vue
@@ -239,10 +239,17 @@ const updateSpeaker = (name: string, updates: Partial<Speaker>): void => {
 };
 
 const handleProviderChange = async (name: string, provider: string) => {
-  updateSpeaker(name, { provider });
-  await nextTick();
+  const { [name]: currentSpeaker, ...currentSpeakers } = { ...speakers.value };
   const voiceId = DEFAULT_VOICE_IDS[provider];
-  updateSpeaker(name, { voiceId });
+  const updatedSpeakers = {
+    ...currentSpeakers,
+    [name]: {
+      provider,
+      voiceId,
+      displayName: currentSpeaker.displayName,
+    },
+  };
+  updateSpeakers(updatedSpeakers);
 };
 
 const handleLanguageChange = (name: string, language: string) => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Switching text-to-speech providers now updates all speakers consistently, preventing partial or out-of-sync updates.
  * Speaker display names are preserved when changing providers.

* **Performance**
  * Faster, smoother updates when selecting a different speech provider.

* **UX**
  * More reliable speaker list behavior during provider changes for a clearer, more consistent experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->