### PR TITLE
Add i18n support to update notifications

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import os from "node:os";
 import started from "electron-squirrel-startup";
 import installExtension, { VUEJS_DEVTOOLS } from "electron-devtools-installer";
-import { updateElectronApp, UpdateSourceType } from "update-electron-app";
+import { updateElectronApp, UpdateSourceType, makeUserNotifier } from "update-electron-app";
 import log from "electron-log/main";
 
 import { registerIPCHandler } from "./ipc_handler";
@@ -11,6 +11,7 @@ import * as projectManager from "./project_manager";
 import * as settingsManager from "./settings_manager";
 import { ENV_KEYS } from "../shared/constants";
 import { getWindowState, saveWindowState } from "./utils/windw_state";
+import config from "../renderer/i18n/index";
 
 log.initialize();
 
@@ -166,6 +167,12 @@ updateElectronApp({
     baseUrl: `https://s3.aws.mulmocast.com/releases/test/${process.platform}/${process.arch}`,
   },
   logger: log,
+  // @ts-expect-error update-electron-app types are not correct
+  notifyUser: () => {
+    const lang = settingsManager.loadAppLanguage();
+    const notifyProps = config.messages[lang as keyof typeof config.messages].updater;
+    return makeUserNotifier(notifyProps);
+  },
 });
 
 // This method will be called when Electron has finished

--- a/src/main/settings_manager.ts
+++ b/src/main/settings_manager.ts
@@ -47,7 +47,7 @@ export const loadSettings = async (): Promise<Settings> => {
   }
 };
 
-export const loadAppLanguageSync = (): string => {
+export const loadAppLanguage = (): string => {
   const settingsPath = getSettingsPath();
   try {
     if (!fs.existsSync(settingsPath)) {

--- a/src/main/settings_manager.ts
+++ b/src/main/settings_manager.ts
@@ -48,17 +48,19 @@ export const loadSettings = async (): Promise<Settings> => {
 };
 
 export const loadAppLanguage = (): string => {
+  const DEFAULT_LANGUAGE = "en";
   const settingsPath = getSettingsPath();
   try {
     if (!fs.existsSync(settingsPath)) {
-      return "en";
+      return DEFAULT_LANGUAGE;
     }
 
     const data = fs.readFileSync(settingsPath, "utf-8");
     const settings = JSON.parse(data);
-    return settings.APP_LANGUAGE || "en";
+    return settings.APP_LANGUAGE || DEFAULT_LANGUAGE;
   } catch (error) {
     console.error("Failed to load app language:", error);
+    return DEFAULT_LANGUAGE;
   }
 };
 

--- a/src/main/settings_manager.ts
+++ b/src/main/settings_manager.ts
@@ -47,6 +47,21 @@ export const loadSettings = async (): Promise<Settings> => {
   }
 };
 
+export const loadAppLanguageSync = (): string => {
+  const settingsPath = getSettingsPath();
+  try {
+    if (!fs.existsSync(settingsPath)) {
+      return "en";
+    }
+
+    const data = fs.readFileSync(settingsPath, "utf-8");
+    const settings = JSON.parse(data);
+    return settings.APP_LANGUAGE || "en";
+  } catch (error) {
+    console.error("Failed to load app language:", error);
+  }
+};
+
 export const saveSettings = async (settings: Settings): Promise<void> => {
   const settingsPath = getSettingsPath();
 

--- a/src/renderer/i18n/en.ts
+++ b/src/renderer/i18n/en.ts
@@ -962,6 +962,12 @@ const lang = {
       sayuri: "Sayuri",
     },
   },
+  updater: {
+    title: "Application Update",
+    detail: "A new version has been downloaded. Restart the application to apply the updates.",
+    restartButtonText: "Restart",
+    laterButtonText: "Later",
+  },
 };
 
 export default lang;

--- a/src/renderer/i18n/ja.ts
+++ b/src/renderer/i18n/ja.ts
@@ -971,6 +971,12 @@ const lang = {
       sayuri: "Sayuri",
     },
   },
+  updater: {
+    title: "アプリケーションのアップデート",
+    detail: "新しいバージョンがダウンロードされました。アプリケーションを再起動してアップデートを適用してください。",
+    restartButtonText: "再起動",
+    laterButtonText: "あとで",
+  },
 };
 
 export default lang;


### PR DESCRIPTION
close: #890


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Localized update notifications now replace generic prompts.
  * Notifications automatically use the app’s selected language (English and Japanese provided).
  * Update dialogs include localized title, details, and actions to restart now or remind later.
  * App safely falls back to English if language settings are missing or unreadable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->