### PR TITLE
Add Dev Helpers for Update Dialog Validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "main": ".vite/build/main.js",
   "scripts": {
     "start": "NODE_ENV=development electron-forge start",
+    "start:show-update-dialog": "NODE_ENV=development electron-forge start -- --show-update-dialog",
     "rebuild:native": "npx electron-rebuild -f",
     "dev": "NODE_ENV=development vite --config vite.renderer.config.ts",
     "package": "npx puppeteer browsers install chrome && electron-forge package",

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -175,6 +175,23 @@ updateElectronApp({
   },
 });
 
+const shouldShowUpdateDialog = isDev && process.argv.includes("--show-update-dialog");
+
+if (shouldShowUpdateDialog) {
+  app.whenReady().then(() => {
+    const lang = settingsManager.loadAppLanguage();
+    const notifyProps = config.messages[lang as keyof typeof config.messages].updater;
+    const showDialog = makeUserNotifier(notifyProps);
+    showDialog({
+      event: {} as unknown as import("electron").Event,
+      releaseNotes: "",
+      releaseName: "MulmoCast",
+      releaseDate: new Date(),
+      updateURL: "",
+    });
+  });
+}
+
 // This method will be called when Electron has finished
 // initialization and is ready to create browser windows.
 // Some APIs can only be used after this event occurs.

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -178,7 +178,7 @@ updateElectronApp({
 const shouldShowUpdateDialog = isDev && process.argv.includes("--show-update-dialog");
 
 if (shouldShowUpdateDialog) {
-  app.whenReady().then(() => {
+  void app.whenReady().then(() => {
     const lang = settingsManager.loadAppLanguage();
     const notifyProps = config.messages[lang as keyof typeof config.messages].updater;
     const showDialog = makeUserNotifier(notifyProps);


### PR DESCRIPTION
用途は開発時のみ
start:show-update-dialog

で update 通知を表示する変更です

<img width="264" height="232" alt="image" src="https://github.com/user-attachments/assets/e227ba34-4c69-4f71-8635-0b2f4d6fd7d8" />
<img width="257" height="229" alt="image" src="https://github.com/user-attachments/assets/fb8ca983-1ae0-4564-8287-c83aabe712c7" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a development-only flow to preview the in-app update notification dialog using a command-line flag.
- Chores
  - Introduced an npm script to start the app with the update dialog visible in development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->