### PR TITLE
i18n: notify - {speechParams} are not set

### DIFF
--- a/src/renderer/i18n/en.ts
+++ b/src/renderer/i18n/en.ts
@@ -781,7 +781,7 @@ const lang = {
         fileNotExist: "The image for beat {beat_index} does not exist or is invalid",
       },
       audio: {
-        generateAudioSpeechParam: "{speechParams} are not set",
+        generateAudioSpeechParam: "{speechParams} (speechParams) are not set",
       },
     },
   },

--- a/src/renderer/i18n/en.ts
+++ b/src/renderer/i18n/en.ts
@@ -775,6 +775,15 @@ const lang = {
       error: "You need setup {keyName}.",
       setup: "Setup",
     },
+    error: {
+      unknownError: "Unknown error occurred",
+      image: {
+        fileNotExist: "The image for beat {beat_index} does not exist or is invalid",
+      },
+      audio: {
+        generateAudioSpeechParam: "{speechParams} are not set",
+      },
+    },
   },
   languages: {
     ja: "Japanese",

--- a/src/renderer/i18n/ja.ts
+++ b/src/renderer/i18n/ja.ts
@@ -781,7 +781,7 @@ const lang = {
         fileNotExist: "ビート{beat_index}の画像が存在しない、もしくは正しくないようです",
       },
       audio: {
-        generateAudioSpeechParam: "{speechParams} がセットされていません",
+        generateAudioSpeechParam: "{speechParams} (speechParams) がセットされていません",
       },
     },
   },

--- a/src/renderer/i18n/ja.ts
+++ b/src/renderer/i18n/ja.ts
@@ -781,7 +781,7 @@ const lang = {
         fileNotExist: "ビート{beat_index}の画像が存在しない、もしくは正しくないようです",
       },
       audio: {
-        generateAudioSpeechParam: "speechParamsがセットされていません",
+        generateAudioSpeechParam: "{speechParams} がセットされていません",
       },
     },
   },

--- a/src/renderer/pages/project/script_editor/beat_editor.vue
+++ b/src/renderer/pages/project/script_editor/beat_editor.vue
@@ -483,7 +483,7 @@ const generateAudio = async () => {
       errorMessage: t("notify.audio.errorMessage"),
     });
   } catch (error) {
-    notifyError(t("ui.common.error"), t("notify.error.audio.generateAudioSpeechParam"));
+    notifyError(t("ui.common.error"), t("notify.error.audio.generateAudioSpeechParam", { speechParams: t("parameters.speechParams.title") }));
     console.log(error);
   }
 };

--- a/src/renderer/pages/project/script_editor/beat_editor.vue
+++ b/src/renderer/pages/project/script_editor/beat_editor.vue
@@ -483,7 +483,10 @@ const generateAudio = async () => {
       errorMessage: t("notify.audio.errorMessage"),
     });
   } catch (error) {
-    notifyError(t("ui.common.error"), t("notify.error.audio.generateAudioSpeechParam", { speechParams: t("parameters.speechParams.title") }));
+    notifyError(
+      t("ui.common.error"),
+      t("notify.error.audio.generateAudioSpeechParam", { speechParams: t("parameters.speechParams.title") }),
+    );
     console.log(error);
   }
 };

--- a/src/renderer/pages/project/script_editor/text_editor.vue
+++ b/src/renderer/pages/project/script_editor/text_editor.vue
@@ -145,7 +145,7 @@ const generateAudio = async (index: number) => {
       errorMessage: t("notify.audio.errorMessage"),
     });
   } catch (error) {
-    notifyError(t("ui.common.error"), t("notify.error.audio.generateAudioSpeechParam"));
+    notifyError(t("ui.common.error"), t("notify.error.audio.generateAudioSpeechParam", { speechParams: t("parameters.speechParams.title") }));
     console.log(error);
   }
 };

--- a/src/renderer/pages/project/script_editor/text_editor.vue
+++ b/src/renderer/pages/project/script_editor/text_editor.vue
@@ -145,7 +145,10 @@ const generateAudio = async (index: number) => {
       errorMessage: t("notify.audio.errorMessage"),
     });
   } catch (error) {
-    notifyError(t("ui.common.error"), t("notify.error.audio.generateAudioSpeechParam", { speechParams: t("parameters.speechParams.title") }));
+    notifyError(
+      t("ui.common.error"),
+      t("notify.error.audio.generateAudioSpeechParam", { speechParams: t("parameters.speechParams.title") }),
+    );
     console.log(error);
   }
 };


### PR DESCRIPTION
エラー文の国際化対応です
関連PR #913 

<img width="443" height="290" alt="image" src="https://github.com/user-attachments/assets/4d45e29e-89c5-45cf-ab9f-fe8e48c6f688" />
<img width="466" height="332" alt="image" src="https://github.com/user-attachments/assets/44d87c09-0900-4311-91e3-5fca51317a7b" />

確認方法 app.vue
```
  notifyError("", t("notify.error.unknownError"));
  notifyError("", t("notify.error.image.fileNotExist", { beat_index: 1 }));
  notifyError(
    "",
    t("notify.error.audio.generateAudioSpeechParam", { speechParams: t("parameters.speechParams.title") }),
  );
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messaging for audio generation by displaying the specific missing parameter name.
  * Added user-facing messages for unknown AI errors and missing image files.
* **Chores**
  * Updated English translations to include new error messages for AI notifications.
  * Refined Japanese translation to use a placeholder for the missing audio parameter, ensuring clearer context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->