### PR TITLE
 feat: standardize image section text sizes to 14px and add descriptions

### DIFF
--- a/src/renderer/i18n/en.ts
+++ b/src/renderer/i18n/en.ts
@@ -698,6 +698,7 @@ const lang = {
       moderation: "Moderation",
       moderationPlaceholder: "ex) low, auto",
       images: "Charactor Image",
+      imagesDescription: "Select the character for this beat",
       imagesEmptyHint: "No images found. Please set references in the Ref tab.",
     },
     audioParams: {

--- a/src/renderer/i18n/ja.ts
+++ b/src/renderer/i18n/ja.ts
@@ -696,7 +696,8 @@ const lang = {
       stylePlaceholder: "例) 鮮やか、自然",
       moderation: "モデレーション",
       moderationPlaceholder: "例) 低、自動",
-      images: "キャラ画像",
+      images: "キャラクター画像",
+      imagesDescription: "このビートで使うキャラクターを選んでください",
       imagesEmptyHint:
         "キャラ画像は設定されていません。生成画像でキャラクターを指定する場合は、「キャラ生成」タブでキャラ画像を設定してください。",
     },

--- a/src/renderer/pages/project/script_editor/beat_style.vue
+++ b/src/renderer/pages/project/script_editor/beat_style.vue
@@ -5,7 +5,7 @@
       <CollapsibleTrigger as-child>
         <div class="mb-3 flex items-center gap-2">
           <Checkbox variant="ghost" size="icon" :modelValue="!!beat?.imageParams" />
-          <h4 class="font-medium text-sm" :class="!beat?.imageParams ? 'text-muted-foreground' : ''">
+          <h4 class="text-sm font-medium" :class="!beat?.imageParams ? 'text-muted-foreground' : ''">
             {{ t("parameters.imageParams.title") }}
           </h4>
         </div>

--- a/src/renderer/pages/project/script_editor/beat_style.vue
+++ b/src/renderer/pages/project/script_editor/beat_style.vue
@@ -5,7 +5,7 @@
       <CollapsibleTrigger as-child>
         <div class="mb-3 flex items-center gap-2">
           <Checkbox variant="ghost" size="icon" :modelValue="!!beat?.imageParams" />
-          <h4 class="font-medium" :class="!beat?.imageParams ? 'text-muted-foreground' : ''">
+          <h4 class="font-medium text-sm" :class="!beat?.imageParams ? 'text-muted-foreground' : ''">
             {{ t("parameters.imageParams.title") }}
           </h4>
         </div>

--- a/src/renderer/pages/project/script_editor/styles/chara_params.vue
+++ b/src/renderer/pages/project/script_editor/styles/chara_params.vue
@@ -1,7 +1,7 @@
 <template>
   <div v-if="Object.keys(images ?? {}).length !== 0" class="mb-4">
     <h4 class="mb-1 block text-sm">{{ t("parameters.imageParams.images") }}</h4>
-    <p class="text-xs text-muted-foreground mb-2">{{ t("parameters.imageParams.imagesDescription") }}</p>
+    <p class="text-muted-foreground mb-2 text-xs">{{ t("parameters.imageParams.imagesDescription") }}</p>
 
     <Card class="mt-2 p-3">
       <div class="space-y-2">

--- a/src/renderer/pages/project/script_editor/styles/chara_params.vue
+++ b/src/renderer/pages/project/script_editor/styles/chara_params.vue
@@ -1,15 +1,17 @@
 <template>
   <div v-if="Object.keys(images ?? {}).length !== 0" class="mb-4">
-    <h4 class="font-medium">{{ t("parameters.imageParams.images") }}</h4>
+    <h4 class="mb-1 block text-sm">{{ t("parameters.imageParams.images") }}</h4>
+    <p class="text-xs text-muted-foreground mb-2">{{ t("parameters.imageParams.imagesDescription") }}</p>
 
-    <Card class="mt-2 p-4">
-      <div class="space-y-3">
-        <div v-for="imageKey in Object.keys(images)" :key="imageKey">
+    <Card class="mt-2 p-3">
+      <div class="space-y-2">
+        <div v-for="imageKey in Object.keys(images)" :key="imageKey" class="flex items-center">
           <Checkbox
             :model-value="(beat?.imageNames ?? Object.keys(images ?? {})).includes(imageKey)"
             @update:modelValue="(val) => updateImageNames(imageKey, val)"
-            class="m-2"
-          />{{ imageKey }}
+            class="mr-2"
+          />
+          <span class="text-sm">{{ imageKey }}</span>
         </div>
       </div>
     </Card>

--- a/src/renderer/pages/project/script_editor/styles/image_params.vue
+++ b/src/renderer/pages/project/script_editor/styles/image_params.vue
@@ -1,6 +1,6 @@
 <template>
   <Card class="mt-4 p-4">
-    <h4 class="font-medium text-sm">{{ t("parameters.imageParams.title") }}</h4>
+    <h4 class="text-sm font-medium">{{ t("parameters.imageParams.title") }}</h4>
 
     <div class="space-y-3">
       <div>

--- a/src/renderer/pages/project/script_editor/styles/image_params.vue
+++ b/src/renderer/pages/project/script_editor/styles/image_params.vue
@@ -1,6 +1,6 @@
 <template>
   <Card class="mt-4 p-4">
-    <h4 class="font-medium">{{ t("parameters.imageParams.title") }}</h4>
+    <h4 class="font-medium text-sm">{{ t("parameters.imageParams.title") }}</h4>
 
     <div class="space-y-3">
       <div>


### PR DESCRIPTION
簡単な説明を
"このビートで使うキャラクターを選んでください"
追加しました

また、余白の調整を行いました

<img width="549" height="190" alt="image" src="https://github.com/user-attachments/assets/5972f181-e8d6-419f-bf6a-b5b79955e810" />

<img width="346" height="195" alt="image" src="https://github.com/user-attachments/assets/4c82d010-050d-40f6-8dcd-97e338f0c6b9" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a descriptive help text under Image Parameters to guide character selection for a beat.

* **Style**
  * Reduced title/header font size in Image Parameters for a cleaner look.
  * Tightened spacing and margins in character/image parameter sections.
  * Improved layout of image entries with checkboxes and clearer labels for better readability.

* **Chores**
  * Updated Japanese translations: refined label for character images and added the new description.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->