### PR TITLE
Persist error notifications

### DIFF
--- a/src/renderer/lib/notification.ts
+++ b/src/renderer/lib/notification.ts
@@ -18,6 +18,8 @@ export const notifyError = (
   toast.error(message, {
     description,
     action,
+    duration: Infinity,
+    closeButton: true,
   });
 };
 
@@ -29,23 +31,22 @@ export const notifyProgress = <T>(
     errorMessage,
   }: { loadingMessage: string | Component; successMessage: string; errorMessage: string },
 ) => {
-  toast.promise(
-    (async () => {
-      const result = await promise;
-      if (result?.result === false) {
-        console.log("error");
-        if (result.error) {
-          throw result.error;
-        }
-        throw Error("Unknown error");
+  const toastId = toast.loading(loadingMessage, {
+    duration: Infinity,
+  });
+  promise
+    .then((result) => {
+      toast.dismiss(toastId);
+      if (result?.result === false || result.error) {
+        console.log(result.error);
+        notifyError(errorMessage, result.error instanceof Error ? result.error.message : "Unknown error");
+      } else {
+        notifySuccess(successMessage);
       }
-      return result;
-    })(),
-    {
-      loading: loadingMessage,
-      success: successMessage,
-      error: errorMessage,
-    },
-  );
+    })
+    .catch((error) => {
+      toast.dismiss(toastId);
+      notifyError(errorMessage, error instanceof Error ? error.message : "Unknown error");
+    });
   return promise;
 };

--- a/src/renderer/lib/notification.ts
+++ b/src/renderer/lib/notification.ts
@@ -37,8 +37,7 @@ export const notifyProgress = <T>(
   promise
     .then((result) => {
       toast.dismiss(toastId);
-      if (result?.result === false || result.error) {
-        console.log(result.error);
+      if (result?.result === false) {
         notifyError(errorMessage, result.error instanceof Error ? result.error.message : "Unknown error");
       } else {
         notifySuccess(successMessage);


### PR DESCRIPTION
close: #891

エラーの場合は、closeButtonを押すまでエラーが消えないようにしました

https://github.com/user-attachments/assets/9c73c589-564b-44e1-8e82-6bf243e96a1a




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Error notifications now remain visible until dismissed and include a close button.
  * Progress notifications show a persistent loading state and deliver clear success or error feedback when operations complete.

* **Bug Fixes**
  * Failed operations reliably surface meaningful error messages instead of generic or missing alerts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->