### PR TITLE
fix file extension

### DIFF
--- a/src/renderer/pages/project/script_editor/beat_editors/media.vue
+++ b/src/renderer/pages/project/script_editor/beat_editors/media.vue
@@ -144,7 +144,7 @@ const handleDrop = (event: DragEvent) => {
       return;
     }
     update("image.type", imageType);
-    const extension = fileType === "jpeg" ? "jpg" : videoSubtypeToExtensions[fileType];
+    const extension = imageType === "image" ? fileType : videoSubtypeToExtensions[fileType];
 
     const reader = new FileReader();
     reader.onload = async () => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved drag-and-drop handling in the media editor to preserve original image file extensions.
  * Ensures image drops (e.g., JPEG, PNG) use the correct extension, reducing mismatches and import issues.
  * Non-image media continues to map to appropriate extensions for reliable attachment and playback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->