### PR TITLE
generate pdf (handout)

### DIFF
--- a/src/renderer/components/product/tabs.vue
+++ b/src/renderer/components/product/tabs.vue
@@ -1,8 +1,8 @@
 <template>
   <Tabs :model-value="currentTab" @update:model-value="handleUpdateTab" class="max-h-[90vh] w-full">
-    <TabsList class="grid w-full grid-cols-3">
+    <TabsList class="grid w-full grid-cols-4">
       <TabsTrigger :value="MULMO_VIEWER_TABS.MOVIE">{{ t("project.productTabs.tabs.movie") }}</TabsTrigger>
-      <!-- TabsTrigger :value="MULMO_VIEWER_TABS.PDF">{{ t("project.productTabs.tabs.pdf") }}</TabsTrigger -->
+      <TabsTrigger :value="MULMO_VIEWER_TABS.PDF">{{ t("project.productTabs.tabs.pdf") }}</TabsTrigger >
       <TabsTrigger :value="MULMO_VIEWER_TABS.PODCAST">{{ t("project.productTabs.tabs.podcast") }}</TabsTrigger>
       <TabsTrigger :value="MULMO_VIEWER_TABS.SLIDE">{{ t("project.productTabs.tabs.slide") }}</TabsTrigger>
     </TabsList>

--- a/src/renderer/components/product/tabs.vue
+++ b/src/renderer/components/product/tabs.vue
@@ -2,7 +2,7 @@
   <Tabs :model-value="currentTab" @update:model-value="handleUpdateTab" class="max-h-[90vh] w-full">
     <TabsList class="grid w-full grid-cols-4">
       <TabsTrigger :value="MULMO_VIEWER_TABS.MOVIE">{{ t("project.productTabs.tabs.movie") }}</TabsTrigger>
-      <TabsTrigger :value="MULMO_VIEWER_TABS.PDF">{{ t("project.productTabs.tabs.pdf") }}</TabsTrigger >
+      <TabsTrigger :value="MULMO_VIEWER_TABS.PDF">{{ t("project.productTabs.tabs.pdf") }}</TabsTrigger>
       <TabsTrigger :value="MULMO_VIEWER_TABS.PODCAST">{{ t("project.productTabs.tabs.podcast") }}</TabsTrigger>
       <TabsTrigger :value="MULMO_VIEWER_TABS.SLIDE">{{ t("project.productTabs.tabs.slide") }}</TabsTrigger>
     </TabsList>

--- a/src/renderer/pages/project/generate.vue
+++ b/src/renderer/pages/project/generate.vue
@@ -53,7 +53,7 @@ const checkboxOptions: { key: OptionKey }[] = [
   { key: "movie" },
   { key: "audio" },
   //  { key: "pdfSlide" },
-  //  { key: "pdfHandout" },
+  { key: "pdfHandout" },
 ];
 
 const options = ref<Record<OptionKey, boolean>>({


### PR DESCRIPTION
言葉足らずで申し訳ないです。#1013 は下のイメージでした。

<img width="327" height="768" alt="image" src="https://github.com/user-attachments/assets/6b90d40a-e269-4f2b-9361-511e534cca24" />

PDF の機能自体は問題ないので、
handout / presenter の並記ではなく、handout のみはどうでしょうか？


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled a visible PDF tab in the tabs list so users can open PDF-related views alongside existing tabs.
  * Reintroduced a PDF handout option in generation settings, letting users opt to include handouts during generation.
  * File icon now displays when PDF slides or handouts are selected.

* **Style**
  * Adjusted the tab layout to a four-column grid to accommodate the additional PDF tab.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->