### PR TITLE
set invalid beat border color to red

### DIFF
--- a/src/renderer/pages/project/script_editor.vue
+++ b/src/renderer/pages/project/script_editor.vue
@@ -186,7 +186,7 @@
             move-class="transition-all duration-300 ease-in-out"
           >
             <div v-for="(beat, index) in mulmoScript?.beats ?? []" :key="beat?.id ?? index" class="relative">
-              <Card class="p-4">
+              <Card class="p-4" :class="isValid(beat) ? '' : 'border-red-400 border-2'">
                 <BeatEditor
                   :beat="beat"
                   :mulmoScript="mulmoScript"
@@ -295,6 +295,7 @@ import YAML from "yaml";
 import {
   MulmoPresentationStyleMethods,
   mulmoScriptSchema,
+  mulmoBeatSchema,
   beatId,
   type MulmoScript,
   type MulmoBeat,
@@ -596,6 +597,11 @@ const deleteReferenceImage = (imageKey: string) => {
     ...props.mulmoScript,
     imageParams: updatedImageParams,
   });
+};
+
+const isValid = (beat: MulmoBeat) => {
+  const res = mulmoBeatSchema.safeParse(beat);
+  return res?.success;
 };
 
 const justSaveAndPushToHistory = () => {

--- a/src/renderer/pages/project/script_editor.vue
+++ b/src/renderer/pages/project/script_editor.vue
@@ -186,7 +186,7 @@
             move-class="transition-all duration-300 ease-in-out"
           >
             <div v-for="(beat, index) in mulmoScript?.beats ?? []" :key="beat?.id ?? index" class="relative">
-              <Card class="p-4" :class="isValid(beat) ? '' : 'border-red-400 border-2'">
+              <Card class="p-4" :class="isValid(beat) ? '' : 'border-2 border-red-400'">
                 <BeatEditor
                   :beat="beat"
                   :mulmoScript="mulmoScript"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Beat Cards in the Script Editor now highlight invalid beats with a red border for quick visual identification.
  * Real-time validity checks power the conditional styling while you browse and edit beats.
  * No configuration required; feedback appears automatically within the editor.
  * Works across all beat lists in the editor.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->