### PR TITLE
upload file size limit and error

### DIFF
--- a/src/renderer/i18n/en.ts
+++ b/src/renderer/i18n/en.ts
@@ -14,7 +14,7 @@ const lang = {
       next: "Next",
 
       // File operations
-      drophere: "Drop file here",
+      drophere: "Drop file here(Upto {maxSizeMB}MB)",
       or: "or",
 
       // Common labels and nouns

--- a/src/renderer/i18n/ja.ts
+++ b/src/renderer/i18n/ja.ts
@@ -14,7 +14,7 @@ const lang = {
       next: "次へ",
 
       // File operations
-      drophere: "画像をここにドロップ",
+      drophere: "画像をここにドロップ({maxSizeMB}MBまで)",
       or: "または",
 
       // Common labels and nouns

--- a/src/renderer/pages/project/script_editor/beat_editors/media.vue
+++ b/src/renderer/pages/project/script_editor/beat_editors/media.vue
@@ -22,7 +22,7 @@
             : 'border-border bg-card text-muted-foreground'
       "
     >
-      {{ t("ui.common.drophere") }}
+      {{ t("ui.common.drophere", { maxSizeMB }) }}
     </div>
     {{ t("ui.common.or") }}
     <div class="flex">
@@ -122,12 +122,13 @@ const videoSubtypeToExtensions = {
   mpg: "mpg",
 };
 
+const maxSizeMB = 50;
+
 const handleDrop = (event: DragEvent) => {
   const files = event.dataTransfer.files;
   if (files.length > 0) {
     const file = files[0];
 
-    const maxSizeMB = 50;
     const maxSize = maxSizeMB * 1024 * 1024;
     if (file.size > maxSize) {
       notifyError(t("notify.error.media.tooLarge", { maxSizeMB }));


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Drag-and-drop media validation with a 50 MB size limit and detection of unsupported file types.
  * Localized error notifications in English and Japanese for oversized or unsupported media.
  * UI upload hint now shows the maximum allowed size.
  * Upload processing halts when size or type violations occur to prevent invalid uploads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->