### PR TITLE
disabled beat audio button

### DIFF
--- a/src/renderer/pages/project/script_editor.vue
+++ b/src/renderer/pages/project/script_editor.vue
@@ -195,6 +195,7 @@
                   :isEnd="(mulmoScript?.beats ?? []).length === index + 1"
                   :isPro="globalStore.userIsPro"
                   :isBeginner="globalStore.userIsBeginner"
+                  :isValidBeat="isValidBeats[index]"
                   :lang="mulmoScript.lang ?? globalStore.settings.APP_LANGUAGE"
                   :audioFile="audioFiles[beat.id]"
                   :imageFile="imageFiles[beat.id]"

--- a/src/renderer/pages/project/script_editor/beat_editor.vue
+++ b/src/renderer/pages/project/script_editor/beat_editor.vue
@@ -55,7 +55,7 @@
           size="sm"
           @click="generateAudio()"
           class="w-fit"
-          :disabled="beat?.text?.length === 0"
+          :disabled="beat?.text?.length === 0 || !isValidBeat"
           >{{ t("ui.actions.generateAudio") }}</Button
         >
         <audio
@@ -339,6 +339,7 @@ interface Props {
   isEnd: boolean;
   isPro: boolean;
   isBeginner: boolean;
+  isValidBeat: boolean;
   mulmoError: string[];
   settingPresence: Record<string, boolean>;
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integrated per-beat validation across text and media editor views.
  * Generate Audio is now enabled only when a beat has text and passes validation, ensuring more reliable output.

* **Bug Fixes**
  * Prevents audio generation for empty or invalid beats, reducing errors and unintended actions.
  * Ensures consistent button behavior between text and media tabs for a smoother editing experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->