### PR TITLE
add error message: text or image required at media beat

### DIFF
--- a/src/renderer/i18n/en.ts
+++ b/src/renderer/i18n/en.ts
@@ -545,6 +545,9 @@ const lang = {
       selectSpeaker: "Select a speaker",
       text: "Text",
       placeholder: "{language} input: {speaker}'s voice content",
+      // Generate audio requirements
+      generateAudioNeedsText: "Text required to '{action}'",
+      generateAudioNeedsMedia: "Image or movie required to '{action}'",
     },
     // Beat type structures (moved from beat.form.*)
     mediaFile: {

--- a/src/renderer/i18n/ja.ts
+++ b/src/renderer/i18n/ja.ts
@@ -543,6 +543,9 @@ const lang = {
       selectSpeaker: "登場人物を選択",
       text: "テキスト",
       placeholder: "{language}で{speaker}の話す内容を書いてください",
+      // Generate audio requirements
+      generateAudioNeedsText: "「{action}」には話す内容が必要です",
+      generateAudioNeedsMedia: "「{action}」には画像または動画が必要です",
     },
     // Beat type structures (moved from beat.form.*)
     mediaFile: {

--- a/src/renderer/pages/project/script_editor/beat_editor.vue
+++ b/src/renderer/pages/project/script_editor/beat_editor.vue
@@ -58,6 +58,11 @@
           :disabled="beat?.text?.length === 0 || !isValidBeat"
           >{{ t("ui.actions.generateAudio") }}</Button
         >
+        <!-- Error messages for disabled Generate Audio button -->
+        <div v-if="beat?.text?.length === 0 || !isValidBeat" class="ml-2 text-sm text-red-600">
+          <span v-if="beat?.text?.length === 0">{{ t("beat.speaker.generateAudioNeedsText", { action: t("ui.actions.generateAudio").toLowerCase() }) }}</span>
+          <span v-else-if="!isValidBeat">{{ t("beat.speaker.generateAudioNeedsMedia", { action: t("ui.actions.generateAudio").toLowerCase() }) }}</span>
+        </div>
         <audio
           :src="audioFile"
           v-if="!!audioFile"

--- a/src/renderer/pages/project/script_editor/beat_editor.vue
+++ b/src/renderer/pages/project/script_editor/beat_editor.vue
@@ -59,7 +59,7 @@
           >{{ t("ui.actions.generateAudio") }}</Button
         >
         <!-- Error messages for disabled Generate Audio button -->
-        <div v-if="beat?.text?.length === 0 || !isValidBeat" class="ml-2 text-sm text-red-600">
+        <div v-if="beat?.text?.length === 0 || !isValidBeat" class="ml-2 text-xs text-red-600">
           <span v-if="beat?.text?.length === 0">{{ t("beat.speaker.generateAudioNeedsText", { action: t("ui.actions.generateAudio").toLowerCase() }) }}</span>
           <span v-else-if="!isValidBeat">{{ t("beat.speaker.generateAudioNeedsMedia", { action: t("ui.actions.generateAudio").toLowerCase() }) }}</span>
         </div>

--- a/src/renderer/pages/project/script_editor/beat_editor.vue
+++ b/src/renderer/pages/project/script_editor/beat_editor.vue
@@ -60,8 +60,12 @@
         >
         <!-- Error messages for disabled Generate Audio button -->
         <div v-if="beat?.text?.length === 0 || !isValidBeat" class="ml-2 text-xs text-red-600">
-          <span v-if="beat?.text?.length === 0">{{ t("beat.speaker.generateAudioNeedsText", { action: t("ui.actions.generateAudio").toLowerCase() }) }}</span>
-          <span v-else-if="!isValidBeat">{{ t("beat.speaker.generateAudioNeedsMedia", { action: t("ui.actions.generateAudio").toLowerCase() }) }}</span>
+          <span v-if="beat?.text?.length === 0">{{
+            t("beat.speaker.generateAudioNeedsText", { action: t("ui.actions.generateAudio").toLowerCase() })
+          }}</span>
+          <span v-else-if="!isValidBeat">{{
+            t("beat.speaker.generateAudioNeedsMedia", { action: t("ui.actions.generateAudio").toLowerCase() })
+          }}</span>
         </div>
         <audio
           :src="audioFile"


### PR DESCRIPTION
音声生成ボタンが disable の理由を横に表示させる変更です

ja
<img width="493" height="387" alt="image" src="https://github.com/user-attachments/assets/3d2a0169-c220-43c1-a8f4-077c735c3a45" />

<img width="522" height="401" alt="image" src="https://github.com/user-attachments/assets/c6fb9efc-3f00-42ae-aac8-5730b749a0cc" />

en
<img width="539" height="414" alt="image" src="https://github.com/user-attachments/assets/fb9dbf62-4ee0-4093-943c-4944c0f232ad" />

<img width="520" height="379" alt="image" src="https://github.com/user-attachments/assets/0ec9688d-c44f-402d-b653-a18da0674ba6" />
