### PR TITLE
disabled beat audio/image/video button when beat is invalid or artifa…

### DIFF
--- a/src/renderer/pages/project/script_editor/beat_editor.vue
+++ b/src/renderer/pages/project/script_editor/beat_editor.vue
@@ -55,7 +55,7 @@
           size="sm"
           @click="generateAudio()"
           class="w-fit"
-          :disabled="beat?.text?.length === 0 || !isValidBeat"
+          :disabled="!isValidBeat || isArtifactGenerating || beat?.text?.length === 0"
           >{{ t("ui.actions.generateAudio") }}</Button
         >
         <!-- Error messages for disabled Generate Audio button -->
@@ -211,7 +211,7 @@
           :imageFile="imageFile"
           :movieFile="movieFile"
           :toggleTypeMode="toggleTypeMode"
-          :disabled="disabledImageGenearte"
+          :disabled="!isValidBeat || isArtifactGenerating || disabledImageGenearte"
           @openModal="openModal"
           @generateImage="generateImageOnlyImage"
         />
@@ -243,7 +243,7 @@
           :toggleTypeMode="toggleTypeMode"
           @openModal="openModal"
           @generateMovie="generateImageOnlyMovie"
-          :disabled="beat.enableLipSync"
+          :disabled="!isValidBeat || isArtifactGenerating || beat.enableLipSync"
         />
       </div>
 
@@ -417,7 +417,9 @@ const isHtmlGenerating = computed(() => {
 const disabledImageGenearte = computed(() => {
   return beatType.value === "imagePrompt" && (props.beat.text || "") === "" && (props.beat.imagePrompt || "") === "";
 });
-
+const isArtifactGenerating = computed(() => {
+  return mulmoEventStore.isArtifactGenerating[projectId.value];
+});
 const changeBeat = (beat: MulmoBeat) => {
   const { id, speaker, text } = props.beat;
   emit("changeBeat", { ...beat, id, speaker, text }, props.index);


### PR DESCRIPTION
…ct is generating.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents starting new generations while another artifact is in progress.
  * Disables Generate Audio, Beat Preview Image, and Beat Preview Movie when input is invalid, generation is ongoing, or lip‑sync constraints apply.
  * Preserves existing checks for empty beat text while adding safer, unified gating.
  * Reduces accidental duplicate actions and related errors for a smoother editing experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->