### PR TITLE
show debugLog if only dev mode

### DIFF
--- a/src/renderer/pages/project.vue
+++ b/src/renderer/pages/project.vue
@@ -209,7 +209,7 @@
             </Card>
 
             <!-- Debug Log Section -->
-            <Card>
+            <Card v-if="isDevelopment">
               <CardContent class="space-y-4 p-4">
                 <!-- Debug Logs -->
                 <DebugLog />
@@ -304,6 +304,8 @@ import { ChatMessage } from "@/types";
 import { type ScriptEditorTab, type MulmoViewerTab } from "../../shared/constants";
 
 import { useImageFiles, useAudioFiles } from "./composable";
+
+const isDevelopment = import.meta.env.DEV;
 
 // State
 const route = useRoute();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a development-only Debug Log section to assist with troubleshooting during development.
  * Debug tools are conditionally displayed only in development builds and are hidden in production.
  * No changes to public functionality; production users will not see any differences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->