### PR TITLE
add description about generate audio on tooltip

### DIFF
--- a/src/renderer/i18n/en.ts
+++ b/src/renderer/i18n/en.ts
@@ -560,6 +560,7 @@ const lang = {
       // Speaker tooltip
       tooltipTitle: "Select {speakerLabel}",
       tooltipDescription: "Manage speakers and voices in the {tab} tab.",
+      tooltipNote: "Regenerate audio after changing speaker.",
     },
     // Beat type structures (moved from beat.form.*)
     mediaFile: {

--- a/src/renderer/i18n/ja.ts
+++ b/src/renderer/i18n/ja.ts
@@ -558,6 +558,7 @@ const lang = {
       // Speaker tooltip
       tooltipTitle: "{speakerLabel}を選択できます",
       tooltipDescription: "登場人物と声は{tab}タブで追加・編集できます",
+      tooltipNote: "変更後は音声を再生成してください",
     },
     // Beat type structures (moved from beat.form.*)
     mediaFile: {

--- a/src/renderer/pages/project/script_editor/beat_editor.vue
+++ b/src/renderer/pages/project/script_editor/beat_editor.vue
@@ -16,6 +16,9 @@
               <div class="text-muted-foreground">
                 {{ t("beat.speaker.tooltipDescription", { tab: "Style" }) }}
               </div>
+              <div class="text-muted-foreground">
+                {{ t("beat.speaker.tooltipNote") }}
+              </div>
             </span>
           </div>
         </div>


### PR DESCRIPTION
#1103 の対応
tooltip の3行目追加しました

<img width="355" height="145" alt="image" src="https://github.com/user-attachments/assets/6bbc36da-459f-41e2-9512-4e81d5c2e929" />

<img width="580" height="201" alt="image" src="https://github.com/user-attachments/assets/77753128-518a-44bc-a3af-67bc734ff04a" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a helpful tooltip reminder to regenerate audio after changing the speaker setting. Tooltip is now available in English and Japanese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->