### PR TITLE
update i18n: text slide params and place holder

### DIFF
--- a/src/renderer/i18n/en.ts
+++ b/src/renderer/i18n/en.ts
@@ -706,7 +706,10 @@ const lang = {
     textSlideParams: {
       title: "Common Slide Parameters",
       css: "CSS Styles",
-      cssDescription: "Enter CSS styles as a single string or multiple lines (applies to Text Slide, Markdown, Chart, and Mermaid).",
+      cssDescription:
+        "Enter CSS styles as a single string or multiple lines (applies to Text Slide, Markdown, Chart, and Mermaid).",
+      cssPlaceholder:
+        "h2 { font-size: 48px; margin-left: 40px; text-align: left }\nh3 { font-size: 36px; margin-left: 40px }\nul { margin-left: 40px }\nol { margin-left: 40px }",
     },
     imageParams: {
       title: "Image Parameters",

--- a/src/renderer/i18n/ja.ts
+++ b/src/renderer/i18n/ja.ts
@@ -705,7 +705,10 @@ const lang = {
     textSlideParams: {
       title: "スライド共通設定",
       css: "CSSスタイル",
-      cssDescription: "CSSスタイルを単一文字列または複数行で入力してください（テキストスライド・Markdown・Chart・Mermaidに適用）",
+      cssDescription:
+        "CSSスタイルを単一文字列または複数行で入力してください（テキストスライド・Markdown・Chart・Mermaidに適用）",
+      cssPlaceholder:
+        "h2 { font-size: 48px; margin-left: 40px; text-align: left }\nh3 { font-size: 36px; margin-left: 40px }\nul { margin-left: 40px }\nol { margin-left: 40px }",
     },
     imageParams: {
       title: "画像生成設定",

--- a/src/renderer/pages/project/script_editor/styles/text_slide_params.vue
+++ b/src/renderer/pages/project/script_editor/styles/text_slide_params.vue
@@ -8,7 +8,7 @@
         <Textarea
           :model-value="cssStylesText"
           @update:model-value="handleCssStylesInput"
-          :placeholder="`${t('ui.common.example')}\nfont-size: 24px;\ncolor: #333;\nmargin: 20px;`"
+          :placeholder="`${t('ui.common.example')}\n${t('parameters.textSlideParams.cssPlaceholder')}`"
           class="font-mono"
           rows="6"
         />


### PR DESCRIPTION
テキストスライド css style 周りの文言更新しました。

<img width="595" height="317" alt="image" src="https://github.com/user-attachments/assets/b548f9cb-7cfe-4a21-8091-a30628013eef" />
<img width="575" height="309" alt="image" src="https://github.com/user-attachments/assets/482caa1e-36c7-450a-8364-57989efae519" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Renamed "Text Slide Parameters" to "Common Slide Parameters" for clarity.
  * Extended CSS guidance to clarify applicability across Text Slide, Markdown, Chart, and Mermaid slide types.
  * Added CSS example placeholder with formatting options.
  * Updated multilingual translations for enhanced consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->