### PR TITLE
fix: i18n escape {}

### DIFF
--- a/src/renderer/i18n/en.ts
+++ b/src/renderer/i18n/en.ts
@@ -709,7 +709,7 @@ const lang = {
       cssDescription:
         "Enter CSS styles as a single string or multiple lines (applies to Text Slide, Markdown, Chart, and Mermaid).",
       cssPlaceholder:
-        "h2 { font-size: 48px; margin-left: 40px; text-align: left }\nh3 { font-size: 36px; margin-left: 40px }\nul { margin-left: 40px }\nol { margin-left: 40px }",
+        "h2 {'{'} font-size: 48px; margin-left: 40px; text-align: left {'}'}\nh3 {'{'} font-size: 36px; margin-left: 40px {'}'}\nul {'{'} margin-left: 40px {'}'}\nol {'{'} margin-left: 40px {'}'}",
     },
     imageParams: {
       title: "Image Parameters",

--- a/src/renderer/i18n/ja.ts
+++ b/src/renderer/i18n/ja.ts
@@ -708,7 +708,7 @@ const lang = {
       cssDescription:
         "CSSスタイルを単一文字列または複数行で入力してください（テキストスライド・Markdown・Chart・Mermaidに適用）",
       cssPlaceholder:
-        "h2 { font-size: 48px; margin-left: 40px; text-align: left }\nh3 { font-size: 36px; margin-left: 40px }\nul { margin-left: 40px }\nol { margin-left: 40px }",
+        "h2 {'{'} font-size: 48px; margin-left: 40px; text-align: left {'}'}\nh3 {'{'} font-size: 36px; margin-left: 40px {'}'}\nul {'{'} margin-left: 40px {'}'}\nol {'{'} margin-left: 40px {'}'}",
     },
     imageParams: {
       title: "画像生成設定",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed CSS code placeholder display in Image Parameters section. Literal curly braces in CSS snippets now render correctly across supported language interfaces. This ensures CSS templates display accurately in English and Japanese, preventing formatting errors and improving the clarity of code examples for better user understanding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->