### PR TITLE
update png file link on script

### DIFF
--- a/docs/guide_youtube/guide00_script_mac/guide00_script.json
+++ b/docs/guide_youtube/guide00_script_mac/guide00_script.json
@@ -79,7 +79,7 @@
           "### 2. Install Application - Drag MulmoCast.app to Applications folder <br> 2. アプリケーションをインストール - MulmoCast.appをアプリケーションフォルダにドラッグ",
           "",
           "<div align=\"center\">",
-          "<img src=\"https://github.com/ystknsh/media/blob/main/guide/guide00_script_mac/images/00_00_download_folder_drag.png?raw=true\" alt=\"Drag to Applications\" width=\"80%\">",
+          "<img src=\"https://github.com/receptron/mulmocast-app/blob/main/docs/guide_youtube/guide00_script_mac/images/00_00_download_folder_drag.png?raw=true\" alt=\"Drag to Applications\" width=\"80%\">",
           "</div>"
         ]
       }
@@ -93,7 +93,7 @@
           "### 3. Launch Application - Click \"Open\" when prompted (first launch only) <br> 3. アプリケーション起動 - 確認画面で「開く」をクリック（初回起動時のみ）",
           "",
           "<div align=\"center\">",
-          "<img src=\"https://github.com/ystknsh/media/blob/main/guide/guide00_script_mac/images/00_02_app_open.png?raw=true\" alt=\"App Open\" width=\"80%\">",
+          "<img src=\"https://github.com/receptron/mulmocast-app/blob/main/docs/guide_youtube/guide00_script_mac/images/00_02_app_open.png?raw=true\" alt=\"App Open\" width=\"80%\">",
           "</div>"
         ]
       }

--- a/docs/guide_youtube/guide00_script_win/guide00_script.json
+++ b/docs/guide_youtube/guide00_script_win/guide00_script.json
@@ -79,7 +79,7 @@
           "### Handle Security Warning - Browser may show security warning: Click three dots (...) icon <br> セキュリティ警告への対処 - ブラウザにセキュリティ警告が表示される場合: 三点ドット（...）アイコンをクリック",
           "",
           "<div align=\"center\">",
-          "<img src=\"https://github.com/ystknsh/media/blob/main/guide/guide00_script_win/images/00_04_security_warning.png?raw=true\" alt=\"Security Warning\" width=\"80%\">",
+          "<img src=\"https://github.com/receptron/mulmocast-app/blob/main/docs/guide_youtube/guide00_script_win/images/00_04_security_warning.png?raw=true\" alt=\"Security Warning\" width=\"80%\">",
           "</div>"
         ]
       }
@@ -93,7 +93,7 @@
           "### Select **Keep** from dropdown <br> ドロップダウンから**保存**を選択",
           "",
           "<div align=\"center\">",
-          "<img src=\"https://github.com/ystknsh/media/blob/main/guide/guide00_script_win/images/00_06_keep_dropdown.png?raw=true\" alt=\"Keep Dropdown\" width=\"80%\">",
+          "<img src=\"https://github.com/receptron/mulmocast-app/blob/main/docs/guide_youtube/guide00_script_win/images/00_06_keep_dropdown.png?raw=true\" alt=\"Keep Dropdown\" width=\"80%\">",
           "</div>"
         ]
       }
@@ -107,7 +107,7 @@
           "### Click dropdown arrow next to delete button - Select **Keep anyway** <br> 削除ボタン横の下矢印をクリック - **保持する**を選択",
           "",
           "<div align=\"center\">",
-          "<img src=\"https://github.com/ystknsh/media/blob/main/guide/guide00_script_win/images/00_08_keep_anyway.png?raw=true\" alt=\"Keep Anyway\" width=\"80%\">",
+          "<img src=\"https://github.com/receptron/mulmocast-app/blob/main/docs/guide_youtube/guide00_script_win/images/00_08_keep_anyway.png?raw=true\" alt=\"Keep Anyway\" width=\"80%\">",
           "</div>"
         ]
       }
@@ -139,7 +139,7 @@
           "### **File:** `MulmoCast-x.x.x-setup.exe` (version may vary) <br> **ファイル:** `MulmoCast-x.x.x-setup.exe` (バージョンは適宜更新されます)",
           "",
           "<div align=\"center\">",
-          "<img src=\"https://github.com/ystknsh/media/blob/main/guide/guide00_script_win/images/00_32_installer_doubleclick.png?raw=true\" alt=\"Installer Double-click\" width=\"80%\">",
+          "<img src=\"https://github.com/receptron/mulmocast-app/blob/main/docs/guide_youtube/guide00_script_win/images/00_32_installer_doubleclick.png?raw=true\" alt=\"Installer Double-click\" width=\"80%\">",
           "</div>"
         ]
       }
@@ -171,7 +171,7 @@
           "### Bypass SmartScreen - Click **More info** link <br> SmartScreenをバイパス - **詳細情報**リンクをクリック",
           "",
           "<div align=\"center\">",
-          "<img src=\"https://github.com/ystknsh/media/blob/main/guide/guide00_script_win/images/00_44_more_info.png?raw=true\" alt=\"More Info\" width=\"80%\">",
+          "<img src=\"https://github.com/receptron/mulmocast-app/blob/main/docs/guide_youtube/guide00_script_win/images/00_44_more_info.png?raw=true\" alt=\"More Info\" width=\"80%\">",
           "</div>"
         ]
       }
@@ -185,7 +185,7 @@
           "### Click **Run anyway** button <br> **実行**ボタンをクリック",
           "",
           "<div align=\"center\">",
-          "<img src=\"https://github.com/ystknsh/media/blob/main/guide/guide00_script_win/images/00_46_run_anyway.png?raw=true\" alt=\"Run Anyway\" width=\"80%\">",
+          "<img src=\"https://github.com/receptron/mulmocast-app/blob/main/docs/guide_youtube/guide00_script_win/images/00_46_run_anyway.png?raw=true\" alt=\"Run Anyway\" width=\"80%\">",
           "</div>"
         ]
       }
@@ -199,7 +199,7 @@
           "### Installation Starting <br> インストール開始",
           "",
           "<div align=\"center\">",
-          "<img src=\"https://github.com/ystknsh/media/blob/main/guide/guide00_script_win/images/01_03_installation_progress.png?raw=true\" alt=\"Installation Progress\" width=\"80%\">",
+          "<img src=\"https://github.com/receptron/mulmocast-app/blob/main/docs/guide_youtube/guide00_script_win/images/01_03_installation_progress.png?raw=true\" alt=\"Installation Progress\" width=\"80%\">",
           "</div>"
         ]
       }

--- a/docs/guide_youtube/guide01/guide01_script.json
+++ b/docs/guide_youtube/guide01/guide01_script.json
@@ -72,7 +72,7 @@
           "### Welcome Screen and Display Language Selection <br> ウェルカム画面と表示言語の選択",
           "",
           "<div align=\"center\">",
-          "<img src=\"https://github.com/ystknsh/media/blob/main/guide/guide01/images/screenshot_00_00.png?raw=true\" alt=\"Welcome Screen\" width=\"80%\">",
+          "<img src=\"https://github.com/receptron/mulmocast-app/blob/main/docs/guide_youtube/guide01/images/screenshot_00_00.png?raw=true\" alt=\"Welcome Screen\" width=\"80%\">",
           "</div>"
         ]
       }
@@ -106,7 +106,7 @@
           "### API Key Settings <br> APIキーの設定",
           "",
           "<div align=\"center\">",
-          "<img src=\"https://github.com/ystknsh/media/blob/main/guide/guide01/images/screenshot_00_16.png?raw=true\" alt=\"Setup Complete\" width=\"80%\">",
+          "<img src=\"https://github.com/receptron/mulmocast-app/blob/main/docs/guide_youtube/guide01/images/screenshot_00_16.png?raw=true\" alt=\"Setup Complete\" width=\"80%\">",
           "</div>"
         ]
       }
@@ -144,7 +144,7 @@
           "### Setup Complete <br> セットアップの完了",
           "",
           "<div align=\"center\">",
-          "<img src=\"https://github.com/ystknsh/media/blob/main/guide/guide01/images/screenshot_00_20.png?raw=true\" alt=\"What's Next\" width=\"70%\">",
+          "<img src=\"https://github.com/receptron/mulmocast-app/blob/main/docs/guide_youtube/guide01/images/screenshot_00_20.png?raw=true\" alt=\"What's Next\" width=\"70%\">",
           "</div>"
           ]
       }
@@ -171,7 +171,7 @@
           "### Creating New Project <br> 新規プロジェクトの作成",
           "",
           "<div align=\"center\">",
-          "<img src=\"https://github.com/ystknsh/media/blob/main/guide/guide01/images/screenshot_00_24.png?raw=true\" alt=\"Dashboard\" width=\"80%\">",
+          "<img src=\"https://github.com/receptron/mulmocast-app/blob/main/docs/guide_youtube/guide01/images/screenshot_00_24.png?raw=true\" alt=\"Dashboard\" width=\"80%\">",
           "</div>"
         ]
       }
@@ -189,7 +189,7 @@
           "</div>",
           "",
           "<div align=\"center\">",
-          "<img src=\"https://github.com/ystknsh/media/blob/main/guide/guide01/images/screenshot_00_30.png?raw=true\" alt=\"Generate Video\" width=\"80%\">",
+          "<img src=\"https://github.com/receptron/mulmocast-app/blob/main/docs/guide_youtube/guide01/images/screenshot_00_30.png?raw=true\" alt=\"Generate Video\" width=\"80%\">",
           "</div>"
         ]
       }
@@ -203,7 +203,7 @@
           "### Project Editor Screen <br> プロジェクト編集画面の確認",
           "",
           "<div align=\"center\">",
-          "<img src=\"https://github.com/ystknsh/media/blob/main/guide/guide01/images/screenshot_00_30.png?raw=true\" alt=\"Generate Video\" width=\"80%\">",
+          "<img src=\"https://github.com/receptron/mulmocast-app/blob/main/docs/guide_youtube/guide01/images/screenshot_00_30.png?raw=true\" alt=\"Generate Video\" width=\"80%\">",
           "</div>"
         ]
       }
@@ -217,7 +217,7 @@
           "### Start Video Generation <br> 動画の生成開始",
           "",
           "<div align=\"center\">",
-          "<img src=\"https://github.com/ystknsh/media/blob/main/guide/guide01/images/screenshot_00_31_8.png?raw=true\" alt=\"Generation Process\" width=\"80%\">",
+          "<img src=\"https://github.com/receptron/mulmocast-app/blob/main/docs/guide_youtube/guide01/images/screenshot_00_31_8.png?raw=true\" alt=\"Generation Process\" width=\"80%\">",
           "</div>"
         ]
       }
@@ -231,7 +231,7 @@
           "### Start Video Generation <br> 動画の生成開始",
           "",
           "<div align=\"center\">",
-          "<img src=\"https://github.com/ystknsh/media/blob/main/guide/guide01/images/screenshot_00_36.png?raw=true\" alt=\"Generation Process\" width=\"70%\">",
+          "<img src=\"https://github.com/receptron/mulmocast-app/blob/main/docs/guide_youtube/guide01/images/screenshot_00_36.png?raw=true\" alt=\"Generation Process\" width=\"70%\">",
           "</div>"
         ]
       }
@@ -245,7 +245,7 @@
           "### Start Video Generation <br> 動画の生成開始",
           "",
           "<div align=\"center\">",
-          "<img src=\"https://github.com/ystknsh/media/blob/main/guide/guide01/images/screenshot_00_58.png?raw=true\" alt=\"Generation Process\" width=\"70%\">",
+          "<img src=\"https://github.com/receptron/mulmocast-app/blob/main/docs/guide_youtube/guide01/images/screenshot_00_58.png?raw=true\" alt=\"Generation Process\" width=\"70%\">",
           "</div>"
         ]
       }
@@ -259,7 +259,7 @@
           "### Start Video Generation <br> 動画の生成開始",
           "",
           "<div align=\"center\">",
-          "<img src=\"https://github.com/ystknsh/media/blob/main/guide/guide01/images/screenshot_01_08.png?raw=true\" alt=\"Generation Process\" width=\"70%\">",
+          "<img src=\"https://github.com/receptron/mulmocast-app/blob/main/docs/guide_youtube/guide01/images/screenshot_01_08.png?raw=true\" alt=\"Generation Process\" width=\"70%\">",
           "</div>"
         ]
       }
@@ -273,7 +273,7 @@
           "### Generation Complete and Video Preview <br> 生成完了と動画プレビュー",
           "",
           "<div align=\"center\">",
-          "<img src=\"https://github.com/ystknsh/media/blob/main/guide/guide01/images/screenshot_01_12.png?raw=true\" alt=\"Generation Complete\" width=\"70%\">",
+          "<img src=\"https://github.com/receptron/mulmocast-app/blob/main/docs/guide_youtube/guide01/images/screenshot_01_12.png?raw=true\" alt=\"Generation Complete\" width=\"70%\">",
           "</div>"
         ]
       }
@@ -287,7 +287,7 @@
           "### Download Video File <br> 動画ファイルのダウンロード",
           "",
           "<div align=\"center\">",
-          "<img src=\"https://github.com/ystknsh/media/blob/main/guide/guide01/images/screenshot_01_23.png?raw=true\" alt=\"Download Button\" width=\"80%\">",
+          "<img src=\"https://github.com/receptron/mulmocast-app/blob/main/docs/guide_youtube/guide01/images/screenshot_01_23.png?raw=true\" alt=\"Download Button\" width=\"80%\">",
           "</div>"
         ]
       }
@@ -301,7 +301,7 @@
           "### File Save Dialog <br> ファイル保存ダイアログ",
           "",
           "<div align=\"center\">",
-          "<img src=\"https://github.com/ystknsh/media/blob/main/guide/guide01/images/screenshot_02_23.png?raw=true\" alt=\"File Save Dialog\" width=\"80%\">",
+          "<img src=\"https://github.com/receptron/mulmocast-app/blob/main/docs/guide_youtube/guide01/images/screenshot_02_23.png?raw=true\" alt=\"File Save Dialog\" width=\"80%\">",
           "</div>"
         ]
       }


### PR DESCRIPTION
script 上のファイル URL を更新しました。
mulmo pdf でリンクの有効性確認しました。
[guide00_script_handout_ja.pdf](https://github.com/user-attachments/files/23045011/guide00_script_handout_ja.pdf)
[guide00_script_handout_ja.pdf](https://github.com/user-attachments/files/23045012/guide00_script_handout_ja.pdf)
[guide01_script_handout_ja.pdf](https://github.com/user-attachments/files/23045013/guide01_script_handout_ja.pdf)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated image references across installation guides (macOS, Windows, and guide materials) to ensure all instructional images display correctly from their updated locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->