### PR TITLE
fix(chart-editor): fix chart title not syncing from JSON to GUI

### DIFF
--- a/src/renderer/pages/project/script_editor/beat_editors/chart.vue
+++ b/src/renderer/pages/project/script_editor/beat_editors/chart.vue
@@ -21,7 +21,7 @@
 
   <Input
     :placeholder="t('beat.chart.titleField')"
-    :model-value="beat?.chart?.title"
+    :model-value="beat?.image?.title"
     @update:model-value="(value) => update('image.title', String(value))"
     @blur="save"
     class="mb-2"


### PR DESCRIPTION
以下の問題に対する変更です

----
OK: BEAT タブで設定 → JSON ファイルに反映される
のですが、
NG: JSON ファイルで変更 → BEAT タブのtitle に反映されないようです

<img width="1028" height="479" alt="image" src="https://github.com/user-attachments/assets/a3c94e58-5eab-4822-a888-b75c7b18e9c8" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected input field binding in the chart editor to properly retrieve and update image title data instead of chart title data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->