### PR TITLE
Add LLM behavior note localization and integrate into chat UI

### DIFF
--- a/src/renderer/i18n/en.ts
+++ b/src/renderer/i18n/en.ts
@@ -500,7 +500,8 @@ const lang = {
       title: "Story Creation with AI Chat",
       aiPoweredGuide: "AI-Powered MulmoScript Generation Guide",
       beginnerDescription: "Create stories through consultation with AI.",
-      llmBehaviorNote: 'You can revert LLM-generated results using "Back" in "{scriptPanel}", or have the LLM regenerate the entire script.',
+      llmBehaviorNote:
+        'You can revert LLM-generated results using "Back" in "{scriptPanel}", or have the LLM regenerate the entire script.',
       advancedDescription: "Use ChatGPT or other AI tools to generate your Script content with these proven prompts",
       enterMessage: "Enter your message:",
       clearChat: "Clear chat",

--- a/src/renderer/i18n/ja.ts
+++ b/src/renderer/i18n/ja.ts
@@ -497,7 +497,8 @@ const lang = {
       title: "AIチャットでストーリー作り",
       aiPoweredGuide: "AIで作るMulmoScriptガイド",
       beginnerDescription: "AIに相談しながらストーリーを作成できます。",
-      llmBehaviorNote: "LLMによる生成結果は「{scriptPanel}」の「戻る」で戻せます。スクリプト全体を再生成させることもできます。",
+      llmBehaviorNote:
+        "LLMによる生成結果は「{scriptPanel}」の「戻る」で戻せます。スクリプト全体を再生成させることもできます。",
       advancedDescription: "用意されたプロンプトでAIが台本案を仕上げます。",
       enterMessage: "AIへのメッセージ",
       clearChat: "会話をリセット",

--- a/src/renderer/pages/project/chat.vue
+++ b/src/renderer/pages/project/chat.vue
@@ -75,7 +75,7 @@
             <span class="text-muted-foreground">{{ `(${llmAgent}${hasExa ? " with Search" : ""})` }}</span>
           </Label>
           <!-- LLM behavior note -->
-          <div class="text-muted-foreground flex-1" style="font-size: 0.7rem;">
+          <div class="text-muted-foreground flex-1" style="font-size: 0.7rem">
             {{ t("project.chat.llmBehaviorNote", { scriptPanel: t("project.menu.script") }) }}
           </div>
         </div>
@@ -114,7 +114,7 @@
           </Button>
         </div>
         <!-- Note about style template -->
-        <div class="text-muted-foreground text-xs flex-1">
+        <div class="text-muted-foreground flex-1 text-xs">
           {{ t("project.chat.styleTemplateNote", { createScriptButton: t("ui.actions.createScript") }) }}
         </div>
       </div>


### PR DESCRIPTION
2箇所修正しました。

1 LLM の生成結果は戻せる旨
2 create script に関する note をボタン横に移動

<img width="1226" height="700" alt="CleanShot 2025-11-04 at 16 27 18@2x" src="https://github.com/user-attachments/assets/d42a15d4-fd01-4c0a-b589-9201f435ca62" />

en 版
<img width="608" height="233" alt="image" src="https://github.com/user-attachments/assets/7778b53a-fa0f-4874-8a2f-3f2183e3486c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added informational note in the chat interface explaining how to revert or regenerate LLM-generated results using available controls.
  * Reorganized chat control buttons into a more compact horizontal layout.
  * Extended multi-language support with translations for new UI elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->