### PR TITLE
add i18n for menu bar

### DIFF
--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -93,7 +93,7 @@ export const getMenu = async () => {
     {
       label: menuProps["help"],
       submenu: [
-        { role: "about" },
+        { role: "about", label: menuProps["about"] },
         {
           label: menuProps["settings"],
           click: () => {
@@ -127,7 +127,22 @@ export const getMenu = async () => {
     },
   ];
 
-  if (isMac) template.unshift({ role: "appMenu" });
+  if (isMac) {
+    template.unshift({
+      role: "appMenu",
+      submenu: [
+        { role: "about", label: menuProps["about"] },
+        { type: "separator" },
+        { role: "services" },
+        { type: "separator" },
+        { role: "hide", label: menuProps["hide"] },
+        { role: "hideOthers", label: menuProps["hideOthers"] },
+        { role: "unhide", label: menuProps["unhide"] },
+        { type: "separator" },
+        { role: "quit", label: menuProps["quit"] },
+      ],
+    });
+  }
 
   const menu = Menu.buildFromTemplate(template);
   return menu;

--- a/src/renderer/i18n/en.ts
+++ b/src/renderer/i18n/en.ts
@@ -1185,6 +1185,9 @@ const lang = {
     close: "Close",
     quit: "Quit",
     about: "About MulmoCast",
+    hide: "Hide MulmoCast",
+    hideOthers: "Hide Others",
+    unhide: "Show All",
   },
 };
 

--- a/src/renderer/i18n/ja.ts
+++ b/src/renderer/i18n/ja.ts
@@ -1185,6 +1185,9 @@ const lang = {
     close: "閉じる",
     quit: "終了",
     about: "MulmoCastについて",
+    hide: "MulmoCastを非表示にする",
+    hideOthers: "その他を非表示にする",
+    unhide: "すべてを表示",
   },
 };
 


### PR DESCRIPTION
- help 内部 の about を修正
- Mac のみ - メニュー（MulmoCast） の 国際化

変更前
<img width="229" height="223" alt="image" src="https://github.com/user-attachments/assets/c57fae0d-7789-4041-a7da-8dfb8317e61f" />
<img width="398" height="201" alt="CleanShot 2025-11-07 at 11 40 38" src="https://github.com/user-attachments/assets/e46c344b-bb4a-4a1a-8658-fb56ef28670e" />

変更後
<img width="294" height="208" alt="image" src="https://github.com/user-attachments/assets/61e32eac-af9b-49cb-86e0-737f5d1129f4" />
<img width="191" height="142" alt="image" src="https://github.com/user-attachments/assets/16d76ffb-5e1c-4de7-bc41-825c361b70bf" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Redesigned macOS application menu with improved structure and clearer labeling for core functions including: about, services, window management options (hide, hide others, unhide), and quit
  * Extended multilingual support with newly translated menu items for window management functions now available in English and Japanese

<!-- end of auto-generated comment: release notes by coderabbit.ai -->