### PR TITLE
Refine linting and TypeScript configs

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -18,6 +18,8 @@ import vueI18n from '@intlify/eslint-plugin-vue-i18n'
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const tsconfigRootDir = __dirname;
 const mainTsconfig = path.resolve(tsconfigRootDir, "tsconfig.json");
+const rendererTsconfig = path.resolve(tsconfigRootDir, "src/renderer/tsconfig.json");
+const vueTsconfig = path.resolve(tsconfigRootDir, "tsconfig.vue.json");
 
 
 // Common base rules configuration
@@ -138,6 +140,8 @@ export default [
         parser: typescriptParser,
         ecmaVersion: "latest",
         sourceType: "module",
+        project: [vueTsconfig],
+        tsconfigRootDir,
         extraFileExtensions: [".vue"],
       },
       globals: {
@@ -151,7 +155,7 @@ export default [
     },
     rules: {
       ...vue.configs["flat/recommended"].rules,
-      ...typescript.configs.recommended.rules,
+      ...typescript.configs["recommended-type-checked"].rules,
       ...baseRules,
       "vue/multi-word-component-names": "off",
       "vue/html-self-closing": [
@@ -177,9 +181,15 @@ export default [
       "@intlify/vue-i18n/no-raw-text": [
         "error",
         {
-          ignorePattern: "[\\-():<>/.]", 
+          ignorePattern: "[\\-():<>/.]",
         },
       ],
+      "@typescript-eslint/no-unsafe-assignment": "off",
+      "@typescript-eslint/no-unsafe-return": "off",
+      "@typescript-eslint/no-unsafe-argument": "off",
+      "@typescript-eslint/no-unsafe-call": "off",
+      "@typescript-eslint/no-unsafe-member-access": "off",
+      "@typescript-eslint/require-await": "off",
       ...sonarjsRules,
     },
     settings: {
@@ -197,6 +207,11 @@ export default [
     files: ["src/renderer/**/*.{js,ts}", "src/types/**/*.{js,ts}"],
     languageOptions: {
       ...baseLanguageOptions,
+      parserOptions: {
+        ...baseLanguageOptions.parserOptions,
+        project: [rendererTsconfig],
+        tsconfigRootDir,
+      },
       globals: {
         ...globals.browser,
         Buffer: 'readonly',
@@ -206,8 +221,14 @@ export default [
       ...basePlugins,
     },
     rules: {
-      ...typescript.configs.recommended.rules,
+      ...typescript.configs["recommended-type-checked"].rules,
       ...baseRules,
+      "@typescript-eslint/no-unsafe-assignment": "off",
+      "@typescript-eslint/no-unsafe-return": "off",
+      "@typescript-eslint/no-unsafe-argument": "off",
+      "@typescript-eslint/no-unsafe-call": "off",
+      "@typescript-eslint/no-unsafe-member-access": "off",
+      "@typescript-eslint/require-await": "off",
       ...sonarjsRules,
     },
     settings: {

--- a/src/renderer/tsconfig.json
+++ b/src/renderer/tsconfig.json
@@ -4,11 +4,13 @@
     "module": "esnext",
     "moduleResolution": "bundler",
     "baseUrl": "./",
+    "lib": ["ESNext", "DOM", "DOM.Iterable"],
+    "types": ["vite/client"],
     "paths": {
       "@/*": ["*"],
       "@/types": ["../types"],
       "@/types/*": ["../types/*"]
     }
   },
-  "include": ["**/*", "../types/**/*"]
+  "include": ["env.d.ts", "**/*.ts", "**/*.tsx", "**/*.d.ts", "../types/**/*"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,13 @@
 {
   "extends": "./tsconfig.common.json",
+  "compilerOptions": {
+    "lib": ["ESNext"],
+    "types": ["node", "electron"],
+    "module": "NodeNext",
+    "moduleResolution": "nodenext",
+    "moduleDetection": "force",
+    "resolveJsonModule": true
+  },
   "include": ["src/main/**/*", "src/shared/**/*", "src/preload/**/*", "src/types/**/*"],
   "exclude": ["node_modules", "dist", "src/renderer"]
 }

--- a/tsconfig.vue.json
+++ b/tsconfig.vue.json
@@ -1,16 +1,15 @@
 {
-  "extends": "./tsconfig.json",
+  "extends": "./src/renderer/tsconfig.json",
   "compilerOptions": {
-    "target": "esnext",
     "module": "esnext",
     "moduleResolution": "bundler",
-    "types": ["vite/client"],
-    "paths": {
-      "@/*": ["src/renderer/*"],
-      "@/types": ["src/types/index"],
-      "@/types/*": ["src/types/*"]
-    }
+    "types": ["vite/client"]
   },
-  "include": ["src/renderer/**/*.vue", "src/types/*"],
+  "include": [
+    "src/renderer/**/*.vue",
+    "src/renderer/**/*.ts",
+    "src/renderer/**/*.d.ts",
+    "src/types/**/*.d.ts"
+  ],
   "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
## Summary
- align the main-process TypeScript configuration with NodeNext module resolution while preserving electron typings
- update renderer and vue tsconfig files to include DOM libraries and explicit include globs for Vue SFCs
- wire eslint to the project tsconfigs so type-aware linting applies to renderer code without unsafe rule noise

## Testing
- npm run type-check:main *(fails: pre-existing type errors in src/main and src/shared)*
- yarn lint *(fails: npm registry returned 403 for tsx package)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690eec42de408333a422a1d418df16da)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated TypeScript and ESLint configuration to enforce stricter type checking across the project with improved configuration inheritance for renderer and Vue components.
  * Refined type definitions and module resolution settings to ensure better compatibility with development tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->