### PR TITLE
fix: add punycode as explicit dependency to resolve build error

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
     "monaco-yaml": "^5.4.0",
     "mulmocast": "^2.0.0",
     "pinia": "^3.0.4",
+    "punycode": "^2.3.1",
     "puppeteer": "24.29.1",
     "radix-vue": "^1.9.17",
     "reka-ui": "^2.6.0",

--- a/vite.main.config.ts
+++ b/vite.main.config.ts
@@ -6,6 +6,9 @@ import ffmpegFfprobeStatic from "ffmpeg-ffprobe-static";
 // Packages to exclude from bundle and load directly from node_modules
 const external_packages = ["jsdom", "mulmocast-vision", "puppeteer", "puppeteer-core"];
 
+// Additional packages to copy (e.g., nested dependencies not auto-detected)
+const additional_packages = ["punycode"];
+
 const isDev = process.env.NODE_ENV === "development";
 
 // https://vitejs.dev/config
@@ -112,6 +115,7 @@ export default defineConfig({
         };
 
         roots.forEach(walk);
+        additional_packages.forEach(walk);
       },
     },
   ],


### PR DESCRIPTION
## 概要
ビルドされたアプリで `punycode` モジュールが見つからないエラーを修正しました。

<img width="200" alt="image" src="https://github.com/user-attachments/assets/08fe8c22-7d22-460f-9424-bf20ebd03fce" />

## 問題
`mulmocast@^2.0.0` へのアップデート後、パッケージされたアプリ起動時に以下のエラーが発生していました：
Error: Cannot find module 'punycode/'

## 根本原因
- `jsdom` の依存関係である `tr46` が `punycode` を使用
- Yarn のホイスティングにより `punycode` はルートの `node_modules` に配置される
- `vite.main.config.ts` の `copy-external-node-modules` プラグインが、ネストされた依存関係を正しく解決できず、`punycode` がビルド出力にコピーされていなかった

## 修正内容
1. `package.json` に `punycode` を明示的に dependencies として追加
2. `vite.main.config.ts` に `additional_packages` 配列を追加し、自動検出されない依存関係を明示的にコピー対象に指定

## テスト
- ビルドされたアプリが正常に起動することを確認
- `punycode` エラーが解消されたことを確認
- `.vite/build/node_modules/punycode` が正しくコピーされていることを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added punycode as a project dependency and updated the build configuration to include it in the external packages processing during the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->