### PR TITLE
Allow selecting media library images for character references

### DIFF
--- a/src/renderer/pages/project/script_editor/beat_editors/media_library_dialog.vue
+++ b/src/renderer/pages/project/script_editor/beat_editors/media_library_dialog.vue
@@ -58,7 +58,7 @@
 </template>
 
 <script setup lang="ts">
-import { onBeforeUnmount, ref, watch } from "vue";
+import { computed, onBeforeUnmount, ref, watch } from "vue";
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { ScrollArea } from "@/components/ui";
 import { useI18n } from "vue-i18n";
@@ -80,6 +80,7 @@ interface ScriptMediaWithPreview extends ProjectScriptMedia {
 
 const props = defineProps<{
   projectId: string | null | undefined;
+  allowedMediaTypes?: ("image" | "movie")[];
 }>();
 
 const emit = defineEmits<{
@@ -91,6 +92,14 @@ const isLoading = ref(false);
 const loadError = ref<string | null>(null);
 const mediaItems = ref<ScriptMediaWithPreview[]>([]);
 let fetchRequestId = 0;
+
+const allowedMediaTypes = computed<("image" | "movie")[]>(() => {
+  const types = props.allowedMediaTypes;
+  if (!types || types.length === 0) {
+    return ["image", "movie"];
+  }
+  return types;
+});
 
 const toArrayBuffer = (data: unknown): ArrayBuffer | null => {
   if (data instanceof ArrayBuffer) {
@@ -140,6 +149,7 @@ const fetchScriptMedia = async () => {
     if (Array.isArray(response)) {
       clearMediaItems();
       const mapped = response
+        .filter((media) => allowedMediaTypes.value.includes(media.mediaType))
         .map((media) => {
           const arrayBuffer = toArrayBuffer(media.data);
           if (!arrayBuffer) {

--- a/src/renderer/pages/project/script_editor/charactor.vue
+++ b/src/renderer/pages/project/script_editor/charactor.vue
@@ -114,7 +114,12 @@
     </div>
   </div>
   <MediaModal v-model:open="modalOpen" type="image" :src="modalSrc" />
-  <MediaLibraryDialog ref="mediaLibraryRef" :project-id="props.projectId" @select="selectScriptImage" />
+  <MediaLibraryDialog
+    ref="mediaLibraryRef"
+    :project-id="props.projectId"
+    :allowed-media-types="['image']"
+    @select="selectScriptImage"
+  />
 </template>
 
 <script setup lang="ts">


### PR DESCRIPTION
## Summary
- add an "Open Media Library" action for each character reference image
- reuse the beat editor media library dialog to pick generated images
- update the reference preview after selecting an image from the library

## Testing
- yarn lint charactor *(fails: npm error 403 Forbidden fetching dependencies)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69144f073f0883338e027016f551f15c)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced media library dialog with type filtering capabilities for images and movies
  * New workflow to select and attach images to script references via media library
  * Added "Open Media Library" button for streamlined image management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->