### PR TITLE
add tooltip for selecting speaker on Beat tab

### DIFF
--- a/src/renderer/pages/project/script_editor/speaker_selector.vue
+++ b/src/renderer/pages/project/script_editor/speaker_selector.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="template-dropdown-container flex items-center gap-4">
-    <div class="group relative">
+    <div class="group relative ml-5">
       <Select v-model="selectedSpeaker">
         <SelectTrigger class="w-auto">
           <SelectValue :placeholder="t('beat.speaker.selectSpeaker')" />


### PR DESCRIPTION
beat に追加した speaker 選択（プルダウン）にツールチップ追加しました

<img width="477" height="183" alt="image" src="https://github.com/user-attachments/assets/e027f930-202f-490c-86d5-59dc11138836" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced the speaker selector with an informational tooltip that appears on hover, providing helpful context and guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->