### PR TITLE
feat: Add dynamic duration field with model-specific tooltips

### DIFF
--- a/src/renderer/pages/project/script_editor/beat_editor.vue
+++ b/src/renderer/pages/project/script_editor/beat_editor.vue
@@ -100,8 +100,8 @@
         @blur="justSaveAndPushToHistory"
       />
       <span class="text-muted-foreground text-sm">{{ t("beat.duration.unit") }}</span>
-      <span class="text-muted-foreground text-sm">
-        {{ t("beat.duration.supportedDurations", { durations: expectDuration?.join(", ") || "" }) }}
+      <span v-if="expectDuration" class="text-muted-foreground text-sm">
+        {{ t("beat.duration.supportedDurations", { durations: expectDuration.join(", ") }) }}
       </span>
       <span
         class="bg-popover text-muted-foreground border-border pointer-events-none absolute bottom-full left-1/2 mb-2 -translate-x-1/2 transform rounded border px-2 py-1 text-xs whitespace-nowrap opacity-0 transition-opacity duration-200 group-hover:opacity-100"


### PR DESCRIPTION
## 変更内容
- 推奨する時間時間 - モデル未選択時は非表示 にしました

変更前
　推奨される動画長: []秒

変更後
　非表示
<img width="581" height="187" alt="image" src="https://github.com/user-attachments/assets/148537f6-3bf8-46f7-90fb-2320964af19e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved duration hint display in the beat editor to only show when duration information is available, eliminating blank or invalid hints from appearing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->