### PR TITLE
fix: Hide supported durations for non-video generation beats

### DIFF
--- a/src/renderer/pages/project/script_editor/beat_editor.vue
+++ b/src/renderer/pages/project/script_editor/beat_editor.vue
@@ -100,7 +100,7 @@
         @blur="justSaveAndPushToHistory"
       />
       <span class="text-muted-foreground text-sm">{{ t("beat.duration.unit") }}</span>
-      <span v-if="expectDuration" class="text-muted-foreground text-sm">
+      <span v-if="expectDuration && beat.moviePrompt" class="text-muted-foreground text-sm">
         {{ t("beat.duration.supportedDurations", { durations: expectDuration.join(", ") }) }}
       </span>
       <span


### PR DESCRIPTION
## 概要
Duration フィールドの「推奨される動画長」表示を、動画生成時のみに限定しました。

### 表示条件
- **表示する**: `expectDuration` が存在 **かつ** `beat.moviePrompt` が存在（動画生成）
- **非表示**: 画像生成（静止画）、モデル未選択


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined duration hint tooltip display to appear only for beats with movie prompts, ensuring duration information is shown only when relevant in the beat editor interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->