### PR TITLE
fix: preserve moviePrompt when generating lipSync with video-based models

### DIFF
--- a/src/main/mulmo/handler_generator.ts
+++ b/src/main/mulmo/handler_generator.ts
@@ -133,7 +133,7 @@ export const mulmoGenerateBeatImage = async (
       beat.moviePrompt = " ";
     }
     if (target === "lipSync") {
-      beat.moviePrompt = "";
+      // beat.moviePrompt = "";
       beat.audioFile = beatAudioPath(context, beat);
     }
     const graphaiCallbacks: CallbackFunction = ({ nodeId, state }) => {


### PR DESCRIPTION
#1262

- リップシンクの生成ボタンを押す
- TTS で音声生成
- 画像生成
- 動画生成 ← 追加する処理
- リップシンク生成

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed lip sync beat image generation to preserve the existing movie prompt instead of clearing it during processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->