### PR TITLE
Add speechName property to all TTS providers and update Gemini voice labels

### DIFF
--- a/src/renderer/i18n/en.ts
+++ b/src/renderer/i18n/en.ts
@@ -213,9 +213,11 @@ const lang = {
     provider: {
       openai: {
         name: "OpenAI",
+        speechName: "OpenAI",
       },
       nijivoice: {
         name: "Nijivoice",
+        speechName: "Nijivoice",
         warning: "Nijivoice service will end on February 4, 2026",
         warningLink: "https://algomatic.jp/news/notice_nijivoice_20251121",
       },
@@ -225,9 +227,11 @@ const lang = {
       },
       gemini: {
         name: "Gemini",
+        speechName: "Gemini",
       },
       elevenlabs: {
         name: "ElevenLabs",
+        speechName: "ElevenLabs",
       },
       replicate: {
         name: "Replicate",

--- a/src/renderer/i18n/ja.ts
+++ b/src/renderer/i18n/ja.ts
@@ -213,9 +213,11 @@ const lang = {
     provider: {
       openai: {
         name: "OpenAI",
+        speechName: "OpenAI",
       },
       nijivoice: {
         name: "Nijivoice",
+        speechName: "Nijivoice",
         warning: "にじボイスは2026年2月4日にサービス終了予定です",
         warningLink: "https://algomatic.jp/news/notice_nijivoice_20251121",
       },
@@ -225,12 +227,15 @@ const lang = {
       },
       gemini: {
         name: "Gemini",
+        speechName: "Gemini",
       },
       elevenlabs: {
         name: "ElevenLabs",
+        speechName: "ElevenLabs",
       },
       replicate: {
         name: "Replicate",
+        speechName: "Replicate",
       },
       alertTemplate: "設定画面で{thing}を設定してください",
     },

--- a/src/renderer/pages/project/script_editor/styles/speech_speaker.vue
+++ b/src/renderer/pages/project/script_editor/styles/speech_speaker.vue
@@ -10,7 +10,7 @@
       </SelectTrigger>
       <SelectContent>
         <SelectItem v-for="provider in providers" :value="provider" :key="provider">
-          {{ getProviderName(provider) }}
+          {{ t("ai.provider." + provider + ".speechName") }}
         </SelectItem>
       </SelectContent>
     </Select>
@@ -130,19 +130,13 @@ import { Label, Input } from "@/components/ui";
 import SettingsAlert from "../settings_alert.vue";
 
 import { useI18n } from "vue-i18n";
-const { t, te } = useI18n();
+const { t } = useI18n();
 
 const props = defineProps<{
   speaker?: Speaker;
   name: string;
   settingPresence: Record<string, boolean>;
 }>();
-
-const getProviderName = (provider: string) => {
-  const speechNameKey = `ai.provider.${provider}.speechName`;
-  const nameKey = `ai.provider.${provider}.name`;
-  return te(speechNameKey) ? t(speechNameKey) : t(nameKey);
-};
 
 const emit = defineEmits<{
   updateSpeakerData: [updates: Partial<Speaker>, overridden?: boolean];


### PR DESCRIPTION
speech pajamas の google にだけ、(GCP 設定必要）と入れるための変更です。

<img width="295" height="320" alt="image" src="https://github.com/user-attachments/assets/721c6fc0-3d2d-438c-8e4e-0a451dc5da10" />


```
    provider: {
      openai: {
        name: "OpenAI",
      },
      nijivoice: {
        name: "Nijivoice",
        warning: "Nijivoice service will end on February 4, 2026",
        warningLink: "https://algomatic.jp/news/notice_nijivoice_20251121",
      },
      google: {
        name: "Google",
        speechName: "Google (GCP required)",
      },
      gemini: {
        name: "Gemini",
      },
      elevenlabs: {
        name: "ElevenLabs",
      },
      replicate: {
        name: "Replicate",
      },
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * UI now uses dedicated "speech" labels for AI providers, ensuring the spoken/displayed provider names come from a single, explicit translation key.
  * Added speech-specific translations for multiple providers in English and Japanese so provider labels display consistently across languages.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->