### PR TITLE
Add friendly display names for Gemini image generation models

### DIFF
--- a/src/renderer/i18n/en.ts
+++ b/src/renderer/i18n/en.ts
@@ -238,6 +238,10 @@ const lang = {
       },
       alertTemplate: "You need to setup {thing}",
     },
+    imageModel: {
+      nanoBananaPro: "Nano Banana Pro (gemini-3-pro-image-preview)",
+      nanoBanana: "Nano Banana (gemini-2.5-flash-image)",
+    },
     apiKeyName: {
       OPENAI_API_KEY: "OpenAI API Key",
       NIJIVOICE_API_KEY: "NijiVoice API Key",

--- a/src/renderer/i18n/ja.ts
+++ b/src/renderer/i18n/ja.ts
@@ -239,6 +239,10 @@ const lang = {
       },
       alertTemplate: "設定画面で{thing}を設定してください",
     },
+    imageModel: {
+      nanoBananaPro: "Nano Banana Pro (gemini-3-pro-image-preview)",
+      nanoBanana: "Nano Banana (gemini-2.5-flash-image)",
+    },
     apiKeyName: {
       OPENAI_API_KEY: "OpenAI API Key",
       NIJIVOICE_API_KEY: "NijiVoice API Key",

--- a/src/renderer/pages/project/script_editor/styles/image_params.vue
+++ b/src/renderer/pages/project/script_editor/styles/image_params.vue
@@ -33,7 +33,7 @@
               :key="model"
               :value="model"
             >
-              {{ model }}
+              {{ getModelDisplayName(model) }}
             </SelectItem>
           </SelectContent>
         </Select>
@@ -86,7 +86,7 @@ import { mulmoOpenAIImageModelSchema } from "mulmocast/browser";
 
 import SettingsAlert from "../settings_alert.vue";
 
-import { IMAGE_PARAMS_DEFAULT_VALUES } from "../../../../../shared/constants";
+import { IMAGE_PARAMS_DEFAULT_VALUES, IMAGE_MODEL_DISPLAY_KEYS } from "../../../../../shared/constants";
 
 const { t } = useI18n();
 const qualityOptions = mulmoOpenAIImageModelSchema.shape.quality._def.innerType.options;
@@ -136,5 +136,10 @@ const handleUpdate = (field: keyof MulmoImageParams, value: string) => {
     ...currentParams,
     [field]: value == "__undefined__" ? undefined : value,
   });
+};
+
+const getModelDisplayName = (modelId: string): string => {
+  const i18nKey = IMAGE_MODEL_DISPLAY_KEYS[modelId];
+  return i18nKey ? t(`ai.imageModel.${i18nKey}`) : modelId;
 };
 </script>

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -408,6 +408,12 @@ export const IMAGE_PARAMS_DEFAULT_VALUES: MulmoImageParams = {
   moderation: undefined,
 };
 
+// Image model display name mappings for i18n
+export const IMAGE_MODEL_DISPLAY_KEYS: Record<string, string> = {
+  "gemini-3-pro-image-preview": "nanoBananaPro",
+  "gemini-2.5-flash-image": "nanoBanana",
+};
+
 export const AUDIO_PARAMS_DEFAULT_VALUES = {
   padding: 0.3,
   introPadding: 1.0,


### PR DESCRIPTION
画像生成モデルに nano banana (愛称）をつけました
<img width="450" height="434" alt="image" src="https://github.com/user-attachments/assets/2b1ac65f-3a0b-4cdf-8638-c9949dd2169f" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* Added support for new image models: Nano Banana Pro and Nano Banana
* Improved model selection UI to display user-friendly names instead of technical identifiers
* Added Japanese language support for image model options

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->