### PR TITLE
hide copy button on beat

### DIFF
--- a/src/renderer/pages/project/script_editor.vue
+++ b/src/renderer/pages/project/script_editor.vue
@@ -115,6 +115,7 @@
                   class="text-muted-foreground hover:text-primary h-5 w-5 cursor-pointer transition"
                 />
                 <Copy
+                  v-if="false"
                   @click="copyBeat(index)"
                   class="text-muted-foreground hover:text-primary h-5 w-5 cursor-pointer transition"
                   :data-testid="`script-editor-text-tab-copy-beat-${index}`"
@@ -243,6 +244,7 @@
                   class="text-muted-foreground hover:text-primary h-5 w-5 cursor-pointer transition"
                 />
                 <Copy
+                  v-if="false"
                   @click="copyBeat(index)"
                   class="text-muted-foreground hover:text-primary h-5 w-5 cursor-pointer transition"
                   :data-testid="`script-editor-media-tab-copy-beat-${index}`"


### PR DESCRIPTION
#1288 ですが、非表示にして v1.0.7 リリースし、
仕様を詰めてから v1.0.8〜 でリリースできればと思います。

- 複製するなら... → 画像/動画も複製して、beat id を変更
- type.beat =beat を実装するなら、複製機能は不要かなとも思い...

まだ、どちらかが良いか決めきれないためです。

また、type.beat =beat は preview なしでも良いかなとも思うためです。
皆さんの要望だと、
- 1つの画像に対して、複数の音声を載せる
  - つまり、1つ前の beat の preview だけ見えていれば良い

- 動画に対して、複数の音声を載せる場合は
  - voice_over の機能になる  
  - こちらも、動画の preview は不要？
  
このあたりの仕様を詰めてから beat の複製（複製という言葉に引っ張られていたしました申し訳ありません）機能にできればと思います。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Hidden Copy icons in Text and Media beat item actions for improved UI clarity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->