### PR TITLE
improve image selector UI with collapsible preview

### DIFF
--- a/src/renderer/i18n/en.ts
+++ b/src/renderer/i18n/en.ts
@@ -129,6 +129,12 @@ const lang = {
       // Project actions
       createNew: "Create New",
       openProjectFolder: "Open Project Folder",
+
+      // UI controls
+      expand: "Edit",
+      collapse: "Preview",
+      selectAll: "Select All",
+      deselectAll: "Deselect All",
     },
 
     // Status messages

--- a/src/renderer/i18n/ja.ts
+++ b/src/renderer/i18n/ja.ts
@@ -129,6 +129,12 @@ const lang = {
       // Project actions
       createNew: "新規作成",
       openProjectFolder: "プロジェクトのフォルダを開く",
+
+      // UI controls
+      expand: "編集",
+      collapse: "プレビュー",
+      selectAll: "全選択",
+      deselectAll: "全解除",
     },
 
     // Status messages

--- a/src/renderer/pages/project/script_editor/styles/chara_params.vue
+++ b/src/renderer/pages/project/script_editor/styles/chara_params.vue
@@ -9,13 +9,50 @@
         <div class="text-muted-foreground">{{ t("parameters.imageParams.imagesDescriptionNote") }}</div>
       </span>
     </div>
+    <div class="mt-2 flex items-center gap-2">
+      <Button variant="ghost" size="sm" @click="isExpanded = !isExpanded" type="button" class="h-8 px-2">
+        <ChevronRight :class="['h-4 w-4 transition-transform', isExpanded && 'rotate-90']" />
+        <span class="ml-1 text-xs">{{ isExpanded ? t("ui.actions.collapse") : t("ui.actions.expand") }}</span>
+      </Button>
+      <div v-if="!isExpanded" class="flex gap-2">
+        <Button variant="outline" size="sm" @click="selectAll" type="button" class="h-8 px-2 text-xs">
+          {{ t("ui.actions.selectAll") }}
+        </Button>
+        <Button variant="outline" size="sm" @click="deselectAll" type="button" class="h-8 px-2 text-xs">
+          {{ t("ui.actions.deselectAll") }}
+        </Button>
+      </div>
+    </div>
     <Card class="mt-2 p-3">
-      <div class="space-y-2">
-        <div v-for="imageKey in Object.keys(images ?? {})" :key="imageKey" class="flex items-center gap-3">
+      <!-- Closed: Show only checked images in a grid -->
+      <div v-if="!isExpanded" class="grid grid-cols-4 gap-2">
+        <div
+          v-for="imageKey in displayedImageKeys"
+          :key="imageKey"
+          class="group relative"
+        >
+          <img
+            v-if="imageRefs[imageKey]"
+            :src="imageRefs[imageKey]"
+            class="h-20 w-full rounded border object-cover"
+            :alt="imageKey"
+          />
+          <div class="bg-background/80 absolute bottom-0 left-0 right-0 truncate px-1 py-0.5 text-xs opacity-0 transition-opacity group-hover:opacity-100">
+            {{ imageKey }}
+          </div>
+        </div>
+      </div>
+      <!-- Expanded: Show all images with checkboxes -->
+      <div v-else class="space-y-2">
+        <div
+          v-for="imageKey in displayedImageKeys"
+          :key="imageKey"
+          class="flex cursor-pointer items-center gap-3 rounded-sm transition-colors hover:bg-accent/50"
+          @click="toggleImageName(imageKey)"
+        >
           <Checkbox
             :model-value="currentValues.includes(imageKey)"
-            @update:modelValue="(val) => updateImageNames(imageKey, val)"
-            class="mr-2"
+            class="mr-2 pointer-events-none"
           />
           <span class="flex-1 text-sm">{{ imageKey }}</span>
           <img
@@ -32,7 +69,8 @@
 
 <script setup lang="ts">
 import { computed, onMounted, ref, watch } from "vue";
-import { Checkbox, Card } from "@/components/ui";
+import { Checkbox, Card, Button } from "@/components/ui";
+import { ChevronRight } from "lucide-vue-next";
 import { type MulmoImageParamsImages, type MulmoBeat } from "mulmocast/browser";
 import { useI18n } from "vue-i18n";
 import { useRoute } from "vue-router";
@@ -55,8 +93,19 @@ const emit = defineEmits<{
 const route = useRoute();
 const projectId = computed(() => route.params.id as string | undefined);
 
+const isExpanded = ref(false);
+
 const currentValues = computed(() => {
   return props.beat?.imageNames ?? Object.keys(props.images ?? {});
+});
+
+const displayedImageKeys = computed(() => {
+  const allKeys = Object.keys(props.images ?? {});
+  if (isExpanded.value) {
+    return allKeys;
+  }
+  // When collapsed, only show checked images
+  return allKeys.filter((key) => currentValues.value.includes(key));
 });
 
 const imageRefs = ref<Record<string, string | null>>({});
@@ -106,5 +155,19 @@ const updateImageNames = (imageKey: string, val: boolean) => {
     : current.filter((key) => key !== imageKey);
 
   emit("updateImageNames", newArray);
+};
+
+const toggleImageName = (imageKey: string) => {
+  const isCurrentlyChecked = currentValues.value.includes(imageKey);
+  updateImageNames(imageKey, !isCurrentlyChecked);
+};
+
+const selectAll = () => {
+  const allKeys = Object.keys(props.images ?? {});
+  emit("updateImageNames", allKeys);
+};
+
+const deselectAll = () => {
+  emit("updateImageNames", []);
 };
 </script>


### PR DESCRIPTION
- Added collapsible view for image reference selection
- Default state: collapsed (preview mode) showing only checked images in grid
- Preview mode: displays checked images in 4-column grid with hover tooltip
- Edit mode: shows all images with checkboxes for selection
- Added "Select All" and "Deselect All" buttons in preview mode
- Clicking anywhere on a row toggles checkbox state
- Changed toggle button labels from "expand/collapse" to "edit/preview"
- Bilingual support (EN/JA)

🤖 Generated with [Claude Code](https://claude.com/claude-code)