### PR TITLE
Update i18n strings for audio generation spillover feature

### DIFF
--- a/src/renderer/i18n/en.ts
+++ b/src/renderer/i18n/en.ts
@@ -594,7 +594,8 @@ const lang = {
       text: "Text",
       placeholder: "{language} input: {speaker}'s voice content",
       // Generate audio requirements
-      generateAudioNeedsText: "Text required to '{action}'. Leave blank to continue audio from the previous beat (spillover feature).",
+      generateAudioNeedsText:
+        "Text required to '{action}'. Leave blank to continue audio from the previous beat (spillover feature).",
       generateAudioNeedsMedia: "Image or movie required to '{action}'. Add, fetch, or generate one from Markdown.",
       // Speaker tooltip
       tooltipTitle: "Select {speakerLabel}",

--- a/src/renderer/i18n/ja.ts
+++ b/src/renderer/i18n/ja.ts
@@ -591,7 +591,8 @@ const lang = {
       text: "テキスト",
       placeholder: "{language}で{speaker}の話す内容を書いてください",
       // Generate audio requirements
-      generateAudioNeedsText: "「{action}」には話す内容が必要です。空白のままにすると前のビートの音声が継続されます(スピルオーバー機能)。",
+      generateAudioNeedsText:
+        "「{action}」には話す内容が必要です。空白のままにすると前のビートの音声が継続されます(スピルオーバー機能)。",
       generateAudioNeedsMedia:
         "「{action}」には画像または動画が必要です。ファイル追加・URL取得・Markdown等から生成してください。",
       // Speaker tooltip


### PR DESCRIPTION
スピルオーバーできることを追加しました

<img width="719" height="305" alt="CleanShot 2025-12-02 at 00 02 30" src="https://github.com/user-attachments/assets/2cef5868-ee53-4b46-a533-a7a7aaa16a96" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated audio generation instructions in English and Japanese to clarify the spillover feature, which allows audio to continue from the previous section when leaving the field blank.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->