### PR TITLE
Add cannotReference localization string for beat edito

### DIFF
--- a/src/renderer/i18n/en.ts
+++ b/src/renderer/i18n/en.ts
@@ -710,6 +710,7 @@ const lang = {
       idField: "Beat ID",
       referenceField: "Beat Reference",
       placeholder: "Select beat to reference",
+      cannotReference: 'Beats with the "{beatLabel}" type cannot be referenced.',
       description: "The image/video automatically updates when the referenced beat changes.",
       invalidReference: "Error: The referenced beat has been deleted. Please select a different beat.",
     },

--- a/src/renderer/i18n/ja.ts
+++ b/src/renderer/i18n/ja.ts
@@ -709,6 +709,7 @@ const lang = {
       idField: "ビートID",
       referenceField: "ビート参照",
       placeholder: "参照するビートを選択",
+      cannotReference: "「{beatLabel}」のビートは参照できません。",
       description: "参照元のビートの画像/動画が変わると、自動的に更新されます",
       invalidReference: "エラー: 参照先のビートが削除されています。別のビートを選択してください。",
     },

--- a/src/renderer/pages/project/script_editor/beat_editor.vue
+++ b/src/renderer/pages/project/script_editor/beat_editor.vue
@@ -215,9 +215,10 @@
             <p v-if="!isReferencedBeatValid" class="text-destructive mt-1 text-sm">
               {{ t("beat.beat.invalidReference") }}
             </p>
-            <p v-else class="text-muted-foreground mt-2 text-sm">
-              {{ t("beat.beat.description") }}
-            </p>
+            <div v-else class="text-muted-foreground mt-2 text-sm">
+              <p>{{ t("beat.beat.cannotReference", { beatLabel: t("beat.beat.label") }) }}</p>
+              <p class="mt-1">{{ t("beat.beat.description") }}</p>
+            </div>
           </template>
           <template v-else-if="beat.image.type === 'voice_over'">
             <Label class="mb-1 block">{{ t("beat.voice_over.label") }}</Label>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Beat editor now displays a warning message when users attempt to reference beats that cannot be referenced, shown alongside the beat description for improved clarity.

* **Localization**
  * Added localization support in English and Japanese for the new beat reference warning message.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->