### PR TITLE
Fix extension matching in fetchAndSave by removing leading dot

### DIFF
--- a/src/main/mulmo/fetch_url.ts
+++ b/src/main/mulmo/fetch_url.ts
@@ -32,7 +32,7 @@ const isVideoExtension = (ext: string): ext is VideoExtension => {
 };
 
 const guessTypeByExt = (ext: string): "image" | "movie" | undefined => {
-  const lowered = ext.toLowerCase();
+  const lowered = ext.toLowerCase().replace(/^\./, "");
   if (isImageExtension(lowered)) {
     return "image";
   }


### PR DESCRIPTION
beat で fetch する際に以下3つのURLで invalid image type と返されたため気がつきました。
通常のドラッグ&ドロップでは問題ありません。

mp4/mp2t/ogg

https://github.com/ystknsh/media/raw/refs/heads/main/media_test/macoro_movie.mp4
https://github.com/ystknsh/media/raw/refs/heads/main/media_test/macoro_movie.mp2t
https://github.com/ystknsh/media/raw/refs/heads/main/media_test/macoro_movie.ogg

---
# fetchAndSave関数の拡張子判定バグ修正

## 概要
`fetchAndSave`関数で拡張子の判定が正しく動作していなかった問題を修正しました。

## 問題

* `extname()`は`.mp4`や`.mp2t`のようにドット付きの拡張子を返す
* `MEDIA_FILE_EXTENSIONS`には`mp4`や`mp2t`のようにドットなしで定義されている
* この不一致により、拡張子による判定が常に失敗していた
* 特に、Content-Typeが`application/octet-stream`を返すサーバー（GitHubのrawコンテンツなど）から`mp2t`や`mp4`ファイルをfetchする際に「invalid image type」エラーが発生していた

## 修正内容

`guessTypeByExt()`関数で、拡張子を小文字化する際に先頭のドットも削除するよう修正しました。

```javascript
// Before
const lowered = ext.toLowerCase();

// After
const lowered = ext.toLowerCase().replace(/^\./, "");
```

## 動作確認

* `.mp2t` → `mp2t` → ホワイトリストに一致 ✅
* `.mp4` → `mp4` → ホワイトリストに一致 ✅
* すでにドットがない場合（`mp4`など）も正常に動作 ✅

## セキュリティ考慮

* ホワイトリスト方式は維持されており、許可された拡張子以外は引き続き拒否される
* パストラバーサル攻撃などのリスクはない

---
関連 #1246 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file type detection to handle extensions with leading periods or mixed-case formatting, enhancing compatibility with various file format inputs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->