### PR TITLE
add error message on bgm page when API missing

### DIFF
--- a/src/renderer/i18n/en.ts
+++ b/src/renderer/i18n/en.ts
@@ -1428,7 +1428,7 @@ const lang = {
     generatingDescription: "AI is generating your background music...",
     empty: {
       title: "No BGM Created Yet",
-      description: "Click 'Create New BGM' to generate your first background music",
+      description: "Click '{buttonLabel}' to generate your first background music",
       requirementNote:
         'BGM generation requires an ElevenLabs paid plan and API Key.\nPlease change the "Music Generation" permission to "Access" in your API Key settings.',
     },

--- a/src/renderer/i18n/ja.ts
+++ b/src/renderer/i18n/ja.ts
@@ -1433,7 +1433,7 @@ const lang = {
     generatingDescription: "AIが背景音楽を生成中...",
     empty: {
       title: "BGMがまだ作成されていません",
-      description: "「新規BGM作成」をクリックして、最初の背景音楽を生成してください",
+      description: "「{buttonLabel}」をクリックして、最初の背景音楽を生成してください",
       requirementNote:
         "BGMを作成するにはElevenLabsの有料プランとAPI Keyが必要です。\nAPI Keyの「Music Generation」権限を「Access」に変更してください。",
     },

--- a/src/renderer/pages/bgm.vue
+++ b/src/renderer/pages/bgm.vue
@@ -22,7 +22,7 @@
           <div class="space-y-4">
             <Music class="text-muted-foreground mx-auto h-16 w-16" />
             <h2 class="text-foreground text-xl font-semibold">{{ t("bgm.empty.title") }}</h2>
-            <p class="text-muted-foreground">{{ t("bgm.empty.description") }}</p>
+            <p class="text-muted-foreground">{{ t("bgm.empty.description", { buttonLabel: t("bgm.createNew") }) }}</p>
             <p class="text-destructive mt-2 text-sm whitespace-pre-line">{{ t("bgm.empty.requirementNote") }}</p>
           </div>
         </div>


### PR DESCRIPTION
- API 設定していない時に「You need to setup ElevenLabs API Key」を表示
- BGM 作成には ElevenLabs の有料プラン、権限変更であることを記述

<img width="782" height="543" alt="image" src="https://github.com/user-attachments/assets/2b002891-37a5-4619-883e-3bbc027d761c" />

<img width="789" height="544" alt="image" src="https://github.com/user-attachments/assets/b35324c8-3b9c-4913-84b0-d03b376dd4ab" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an API Key alert in the BGM section to inform users about ElevenLabs configuration requirements
  * Enhanced BGM empty state with dynamic, contextual messaging

* **Documentation**
  * Updated localized text with detailed ElevenLabs API key and plan requirements for BGM generation

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->