### PR TITLE
feat: Make image override label clickable in beat editor

### DIFF
--- a/src/renderer/pages/project/script_editor/beat_style.vue
+++ b/src/renderer/pages/project/script_editor/beat_style.vue
@@ -7,7 +7,11 @@
       @update:model-value="updateBeatImageParams"
     />
     <div class="group relative">
-      <Label class="cursor-pointer" :class="!beat?.imageParams ? 'text-muted-foreground' : ''">
+      <Label
+        class="cursor-pointer"
+        :class="!beat?.imageParams ? 'text-muted-foreground' : ''"
+        @click="updateBeatImageParams(!beat?.imageParams)"
+      >
         {{ t("parameters.imageParams.customTitle") }}
       </Label>
       <span


### PR DESCRIPTION
## 概要
ビートエディタの画像生成上書き設定で、ラベルテキストをクリックしてもチェックボックスと同様に設定を開閉できるように改善しました。

## 変更内容
### beat_style.vue
- 「このビートの画像生成を上書きする」ラベルに`@click`イベントを追加
- ラベルクリック時に`updateBeatImageParams`を呼び出し、画像パラメータの設定を切り替え


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to toggle image parameters directly by clicking the label in the beat editor, providing an alternative interaction method alongside the existing checkbox control.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->