### PR TITLE
feat: Make empty image list clickable to expand in beat editor

### DIFF
--- a/src/renderer/pages/project/script_editor/styles/chara_params.vue
+++ b/src/renderer/pages/project/script_editor/styles/chara_params.vue
@@ -24,7 +24,10 @@
       </div>
     </div>
     <Card
-      :class="['mt-2 p-3', isEmptyAndCollapsed && 'cursor-pointer transition-colors hover:bg-accent hover:text-accent-foreground']"
+      :class="[
+        'mt-2 p-3',
+        isEmptyAndCollapsed && 'hover:bg-accent hover:text-accent-foreground cursor-pointer transition-colors',
+      ]"
       @click="isEmptyAndCollapsed ? (isExpanded = true) : undefined"
     >
       <!-- Closed: Show only checked images in a grid -->


### PR DESCRIPTION
素材を選択していないときに説明表示に変更しました。

<img width="547" height="361" alt="CleanShot 2025-12-12 at 14 58 23" src="https://github.com/user-attachments/assets/e18ca002-ae6f-4931-9466-6eeebd166d97" />

### 参考 - 素材選択時はこれまで通り
<img width="518" height="270" alt="image" src="https://github.com/user-attachments/assets/4964934c-c08b-49d0-a021-a2c99bd317c7" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved handling of empty image lists with interactive expand prompts and hover feedback
  * Enhanced collapsed view with contextual placeholder messaging when no images are present
  * Added visual guidance through interactive styling to help users discover expandable sections

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->