### PR TITLE
add decoration sample

### DIFF
--- a/src/renderer/pages/project/script_editor/styles/speech_speaker.vue
+++ b/src/renderer/pages/project/script_editor/styles/speech_speaker.vue
@@ -218,7 +218,7 @@ const DEFAULT_VOICE_IDS: Record<string, string> = providers.reduce((tmp, provide
 
 type Provider = keyof typeof VOICE_LISTS;
 
-const defaultDecoration = 'neutral';
+const defaultDecoration = "neutral";
 
 const mulmoScriptHistoryStore = useMulmoScriptHistoryStore();
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for decorated Kotodama voice variants, letting users choose speech style decorations.
  * Nijivoice and Kotodama audio are now handled separately for more consistent playback.
  * Kotodama now falls back to a default "neutral" decoration when no decoration is set.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->