### PR TITLE
fix When the component mounts with an already-valid script, the downl…

### DIFF
--- a/src/renderer/pages/project.vue
+++ b/src/renderer/pages/project.vue
@@ -405,8 +405,8 @@ onUnmounted(() => {
 
 watch(
   () => mulmoScriptHistoryStore.isValidScript,
-  (newVal) => {
-    if (newVal) {
+  (newVal, oldVal) => {
+    if (newVal && !oldVal) {
       downloadAudioFiles(projectId.value, mulmoScriptHistoryStore.lang);
       downloadImageFiles(projectId.value);
     }


### PR DESCRIPTION
…oad functions are called twice.