### PR TITLE
refactor: Convert lip sync requirement message to hover tooltip

### DIFF
--- a/src/renderer/pages/project/script_editor/beat_editor.vue
+++ b/src/renderer/pages/project/script_editor/beat_editor.vue
@@ -403,7 +403,7 @@
       <!-- left: lipSync edit -->
       <div class="flex flex-col gap-1" v-if="enableLipSync && hasLipSyncKey && !isVoiceOver">
         <!-- movie edit -->
-        <div class="flex items-center gap-2">
+        <div class="group relative flex items-center gap-2">
           <Checkbox
             variant="ghost"
             size="icon"
@@ -412,12 +412,15 @@
             :disabled="!canEnableLipSync"
           />
           <Label class="block" :class="{ 'opacity-50': !canEnableLipSync }">{{ t("beat.lipSync.label") }} </Label>
+          <span
+            v-if="!canEnableLipSync"
+            class="bg-popover text-muted-foreground border-border pointer-events-none absolute bottom-full left-0 mb-2 transform rounded border px-2 py-1 text-xs whitespace-nowrap opacity-0 transition-opacity duration-200 group-hover:opacity-100"
+          >
+            {{ lipSyncRequiresMediaMessage }}
+          </span>
         </div>
         <div v-if="lipSyncModelDescription" class="text-muted-foreground ml-6 text-sm">
           {{ lipSyncModelDescription }}
-        </div>
-        <div v-if="!canEnableLipSync" class="text-muted-foreground ml-6 text-sm">
-          {{ lipSyncRequiresMediaMessage }}
         </div>
       </div>
       <!-- right: lipSync preview -->


### PR DESCRIPTION
## 概要
設定内容が増えて、ビートの中が混んできたので、省スペース化しました。
リップシンク機能の要件メッセージを、常時表示からホバー時のツールチップ表示に変更しました。

<img width="1016" height="473" alt="CleanShot 2025-12-15 at 00 35 51" src="https://github.com/user-attachments/assets/09a4279e-7d2c-4210-a98e-3929f7f11875" />


## 変更内容
- リップシンクのチェックボックス・ラベル部分にホバーツールチップを追加
- 従来は常時表示されていた要件メッセージ（画像プロンプトまたは動画プロンプトの入力が必要）をツールチップ化
- UIの整理により、画面の情報密度を改善

## 技術的詳細
- `beat_editor.vue` の lip sync セクションに `group relative` クラスを追加
- 既存の duration フィールドと同じツールチップパターンを適用

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved Lip Sync control layout in the beat editor by displaying unavailability messages as contextual tooltips instead of persistent UI elements. The tooltip now appears only when hovering over the control group and Lip Sync cannot be enabled, providing a cleaner interface.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->