### PR TITLE
Reorder kotodama audio preview after nijivoice parameters

### DIFF
--- a/src/renderer/pages/project/script_editor/styles/speech_speaker.vue
+++ b/src/renderer/pages/project/script_editor/styles/speech_speaker.vue
@@ -90,13 +90,6 @@
       volume="0.3"
     />
   </div>
-  <div v-if="localizedSpeaker.provider === 'kotodama'">
-    <audio
-      :src="`https://github.com/receptron/mulmocast-media/raw/refs/heads/main/voice/${localizedSpeaker.provider}/${getVoiceList(localizedSpeaker.provider).find((a) => a.id === localizedSpeaker.voiceId).key}_${currentDecoration}.mp3`"
-      controls
-      volume="0.3"
-    />
-  </div>
   <div v-if="localizedSpeaker.provider === 'nijivoice'">
     <!-- speed -->
     <Label class="text-xs">{{ t("parameters.speechParams.speed") }}</Label>
@@ -124,6 +117,13 @@
         </SelectItem>
       </SelectContent>
     </Select>
+  </div>
+  <div v-if="localizedSpeaker.provider === 'kotodama'">
+    <audio
+      :src="`https://github.com/receptron/mulmocast-media/raw/refs/heads/main/voice/${localizedSpeaker.provider}/${getVoiceList(localizedSpeaker.provider).find((a) => a.id === localizedSpeaker.voiceId).key}_${currentDecoration}.mp3`"
+      controls
+      volume="0.3"
+    />
   </div>
   <div v-if="localizedSpeaker.provider === 'openai' || !localizedSpeaker.provider">
     <!-- instruction -->


### PR DESCRIPTION
## 概要
`speech_speaker.vue`において、kotodamaプロバイダーのオーディオプレビュー要素を移動させました。
音声スタイルごとに声の視聴機能をつけたため。

<img width="503" height="489" alt="CleanShot 2025-12-15 at 01 37 21" src="https://github.com/user-attachments/assets/3940d62f-a109-4148-93f3-9e8b7f6e1b11" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Adjusted the layout order of the audio controls in the speech speaker interface for improved visual organization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->