### PR TITLE
Hide Advanced Settings section for voice_over beats and when empty

### DIFF
--- a/src/renderer/pages/project/script_editor/beat_editor.vue
+++ b/src/renderer/pages/project/script_editor/beat_editor.vue
@@ -690,7 +690,7 @@ const beatTransitionDuration = computed(() => {
 
 // Show BeatStyle settings only for imagePrompt beats in Pro mode
 const showBeatStyleSettings = computed(() => {
-  return beatType.value === 'imagePrompt' && props.isPro;
+  return beatType.value === "imagePrompt" && props.isPro;
 });
 
 // Show Transition settings for beat 2 onwards, but not for voice_over type


### PR DESCRIPTION
関連 #1440 

ボイスオーバーの時にビートの詳細設定できないように非表示にしました。
合わせて、詳細設定周りの条件(condition）をcomputed へ移行しました。
<img width="968" height="936" alt="CleanShot 2025-12-15 at 16 24 08@2x" src="https://github.com/user-attachments/assets/6e9e2b9a-07e6-4421-b7cd-316076f0c491" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized visibility logic for beat editor settings to make UI behavior more consistent.
  * Improved handling and explicit exclusion of voice-over beats from certain setting sections.
  * Adjusted Advanced Settings header and trigger behavior to better reflect when options are available.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->