### PR TITLE
Stop BGM playback when leaving the BGM management page

### DIFF
--- a/src/renderer/pages/bgm.vue
+++ b/src/renderer/pages/bgm.vue
@@ -156,7 +156,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted } from "vue";
+import { ref, onMounted, onBeforeUnmount } from "vue";
 import { Plus, Music, Play, Pause, Pencil, Trash2, Loader2 } from "lucide-vue-next";
 import { useI18n } from "vue-i18n";
 import dayjs from "dayjs";
@@ -419,5 +419,17 @@ const formatDate = (dateString: string) => {
 
 onMounted(() => {
   loadBgmList();
+});
+
+onBeforeUnmount(() => {
+  // Stop audio playback when leaving the page
+  if (audioElement.value) {
+    audioElement.value.pause();
+    audioElement.value.src = "";
+  }
+  // Reset playing state
+  bgmList.value.forEach((bgm) => {
+    bgm.playing = false;
+  });
 });
 </script>


### PR DESCRIPTION
## 概要
BGM管理ページで音楽を再生中に別のページに遷移した際、バックグラウンドで音楽が流れ続ける問題を修正しました。

## 変更内容
- `onBeforeUnmount`ライフサイクルフックを追加
- ページ離脱時にオーディオ再生を自動停止
- オーディオ要素のリソースを適切に解放
- 全BGMアイテムの再生状態をリセット

## 修正対象ファイル
- `src/renderer/pages/bgm.vue`

## 動作
ページ離脱時に以下の処理を実行：
1. `audioElement.pause()` で再生を停止
2. `audioElement.src = ""` でメモリを解放
3. 全BGMアイテムの `playing` 状態を `false` にリセット

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where background music playback would continue running persistently in the background after users navigated away from the music page. Audio playback now properly terminates and the playing state resets correctly when exiting the page, ensuring no unintended audio persists across page navigation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->