### PR TITLE
Save chat settings per project with hybrid fallback to global defaults

### DIFF
--- a/src/renderer/pages/project.vue
+++ b/src/renderer/pages/project.vue
@@ -39,7 +39,9 @@
                 <Chat
                   :mulmoScript="mulmoScriptHistoryStore.currentMulmoScript"
                   :messages="projectMetadata?.chatMessages"
+                  :projectMetadata="projectMetadata"
                   @update:updateChatMessages="handleUpdateChatMessages"
+                  @update:projectMetadata="handleUpdateProjectMetadata"
                   @updateMulmoScript="handleUpdateMulmoScriptWithNotify"
                   @resetMediaFiles="resetMediaFiles"
                   class="flex h-full flex-col"
@@ -513,6 +515,11 @@ const saveProjectMetadataDebounced = useDebounceFn(saveProjectMetadata, 1000);
 const handleUpdateChatMessages = (messages: ChatMessage[]) => {
   projectMetadata.value.chatMessages = messages;
   saveProjectMetadataDebounced();
+};
+
+const handleUpdateProjectMetadata = (updatedMetadata: ProjectMetadata) => {
+  projectMetadata.value = updatedMetadata;
+  saveProjectMetadata({ updateTimestamp: false });
 };
 
 const handleUpdateScriptEditorActiveTab = async (tab: ScriptEditorTab) => {

--- a/src/renderer/pages/project/chat_system_prompt.ts
+++ b/src/renderer/pages/project/chat_system_prompt.ts
@@ -15,7 +15,7 @@ export const conversationModes = [
 ];
 
 export const useSystemPrompt = () => {
-  const conversationMode = ref<ConversationMode>("dialogue");
+  const conversationMode = ref<ConversationMode>("presentation");
   const conversationSystemPrompt = computed(() => {
     const conversationSystemPrompts = {
       presentation:

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -19,6 +19,8 @@ export type ProjectMetadata = {
   presentationStyle?: MulmoPresentationStyle;
   scriptEditorActiveTab: ScriptEditorTab;
   mulmoViewerActiveTab?: MulmoViewerTab;
+  chatConversationMode?: string;
+  chatTemplateIndex?: number;
 };
 export type Project = {
   metadata: ProjectMetadata;


### PR DESCRIPTION
## 概要
チャット設定（会話モードとスタイルテンプレート選択）の保存方法、プロジェクトごとの設定を可能にしました。

関連 PR #1472 
関連 Issues #1476 

## 変更内容
### ハイブリッド方式の実装
プロジェクトごとの設定を優先しつつ、グローバル設定をデフォルトとして使用する仕組みを導入しました。

**優先順位:**
1. プロジェクト設定（`ProjectMetadata.chatConversationMode`, `chatTemplateIndex`）
2. グローバル設定（`Settings.CHAT_CONVERSATION_MODE`, `CHAT_TEMPLATE_INDEX`）
3. コンポーネントデフォルト（`"presentation"`, `-1`）

### 主な変更
1. **型定義の追加** ([src/types/index.ts](../blob/HEAD/src/types/index.ts))
   - `ProjectMetadata` に `chatConversationMode` と `chatTemplateIndex` を追加

2. **チャットコンポーネントの改善** ([src/renderer/pages/project/chat.vue](../blob/HEAD/src/renderer/pages/project/chat.vue))
   - プロジェクトメタデータを props として受け取り
   - マウント時にハイブリッド方式で設定を読み込み
   - 設定変更時にプロジェクトメタデータに保存

3. **親コンポーネントの対応** ([src/renderer/pages/project.vue](../blob/HEAD/src/renderer/pages/project.vue))
   - `handleUpdateProjectMetadata` ハンドラを追加
   - プロジェクトメタデータの更新を適切に処理

4. **デフォルト値の変更** ([src/renderer/pages/project/chat_system_prompt.ts](../blob/HEAD/src/renderer/pages/project/chat_system_prompt.ts))
   - 会話モードのデフォルトを `"dialogue"` から `"presentation"` に変更

## 動作
- **新規プロジェクト**: グローバル設定（またはデフォルト）が適用される
- **既存プロジェクト**: プロジェクトごとの設定が保持される
- **設定変更**: 自動的にプロジェクトメタデータに保存される
- **プロジェクト切り替え**: それぞれのプロジェクトの設定が復元される

## テスト方法
1. 既存プロジェクトで会話モードを変更
2. 別のプロジェクトに切り替え、設定が独立していることを確認
3. 新規プロジェクトを作成し、デフォルト設定が適用されることを確認
4. `meta.json` に設定が保存されていることを確認


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Chat settings (conversation mode and template selection) are now saved per-project, allowing you to maintain unique chat preferences for each project independently.
  * Updated the default conversation mode to presentation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->