### PR TITLE
Add i18n support for ElevenLabs voice cloning subscription error

### DIFF
--- a/src/main/mulmo/handler_voice_clone.ts
+++ b/src/main/mulmo/handler_voice_clone.ts
@@ -42,6 +42,16 @@ const handleBadRequestError = (error: unknown, operationName: string): void => {
       });
     }
 
+    if (status === "can_not_use_instant_voice_cloning") {
+      throw new Error("Instant voice cloning not available", {
+        cause: {
+          action: "voiceClone",
+          type: "can_not_use_instant_voice_cloning",
+          agentName: "voiceCloneElevenlabsAgent",
+        },
+      });
+    }
+
     // Handle other 400 errors generically
     throw new Error(`${operationName}: ${message || "Bad request"}`, {
       cause: {

--- a/src/renderer/i18n/en_notify.ts
+++ b/src/renderer/i18n/en_notify.ts
@@ -141,6 +141,12 @@ export const en_notify = {
         voiceCloneElevenlabsAgentAction: "View Details",
         voiceCloneElevenlabsAgentUrl: "https://elevenlabs.io/app/voice-lab",
       },
+      can_not_use_instant_voice_cloning: {
+        voiceCloneElevenlabsAgent:
+          "Your subscription does not have access to instant voice cloning. Please upgrade your ElevenLabs plan to use this feature.",
+        voiceCloneElevenlabsAgentAction: "View Details",
+        voiceCloneElevenlabsAgentUrl: "https://elevenlabs.io/app/subscription",
+      },
       badRequest: {
         voiceCloneElevenlabsAgent: "Voice clone operation failed. Please check your file and try again.",
       },

--- a/src/renderer/i18n/ja_notify.ts
+++ b/src/renderer/i18n/ja_notify.ts
@@ -142,6 +142,12 @@ export const ja_notify = {
         voiceCloneElevenlabsAgentAction: "詳細を見る",
         voiceCloneElevenlabsAgentUrl: "https://elevenlabs.io/app/voice-lab",
       },
+      can_not_use_instant_voice_cloning: {
+        voiceCloneElevenlabsAgent:
+          "ご契約のプランでは音声クローン機能を利用できません。ElevenLabsのプランをアップグレードしてこの機能をご利用ください。",
+        voiceCloneElevenlabsAgentAction: "詳細を見る",
+        voiceCloneElevenlabsAgentUrl: "https://elevenlabs.io/app/subscription",
+      },
       badRequest: {
         voiceCloneElevenlabsAgent: "音声クローンの操作に失敗しました。ファイルを確認して再度お試しください。",
       },

--- a/src/renderer/lib/error.ts
+++ b/src/renderer/lib/error.ts
@@ -176,6 +176,9 @@ export const convCauseToErrorMessage = (cause: {
     if (cause.type === "voice_limit_reached") {
       return [["notify.error", cause.action, cause.type, cause.agentName].join(".")];
     }
+    if (cause.type === "can_not_use_instant_voice_cloning") {
+      return [["notify.error", cause.action, cause.type, cause.agentName].join(".")];
+    }
     if (cause.type === "apiError") {
       if (prioritizedApiErrorTargets.has(cause.target)) {
         return [

--- a/src/renderer/pages/voice_clone.vue
+++ b/src/renderer/pages/voice_clone.vue
@@ -249,7 +249,7 @@ const hasApiKey = computed(() => {
   return globalStore.settingPresence["ELEVENLABS_API_KEY"] === true;
 });
 
-// Helper function to handle voice clone errors with voice_limit_reached support
+// Helper function to handle voice clone errors with voice_limit_reached and can_not_use_instant_voice_cloning support
 const handleVoiceCloneError = (error: unknown, fallbackMessage: string) => {
   const errorWithCause = error as Error & { cause?: { type: string; agentName: string; action?: string } };
 
@@ -257,7 +257,8 @@ const handleVoiceCloneError = (error: unknown, fallbackMessage: string) => {
     const { type, agentName, action } = errorWithCause.cause;
     const i18nKey = action ? `notify.error.${action}.${type}.${agentName}` : `notify.error.${type}.${agentName}`;
 
-    if (type === "voice_limit_reached") {
+    // Handle errors with action buttons (voice_limit_reached, can_not_use_instant_voice_cloning)
+    if (type === "voice_limit_reached" || type === "can_not_use_instant_voice_cloning") {
       const actionKey = `${i18nKey}Action`;
       const urlKey = `${i18nKey}Url`;
 


### PR DESCRIPTION
関連 Issue https://github.com/receptron/mulmocast-app/issues/1467

elevenlabs voice clone の error handling です。
プランによって利用できない時のエラーです。

<img width="421" height="316" alt="image" src="https://github.com/user-attachments/assets/ab31af60-2912-48f7-8514-15999040ab7b" />


--- 以下 Claude Code --- 
## 概要
ElevenLabsの音声クローン機能で発生する `can_not_use_instant_voice_cloning` エラーを国際化対応しました。

## 変更内容

### 1. 翻訳メッセージの追加
- 英語・日本語の翻訳メッセージを追加
- アクションボタン付きのエラー通知に対応
- サブスクリプション画面へのリンクを設定

### 2. バックエンドのエラー処理
- `handler_voice_clone.ts` で `can_not_use_instant_voice_cloning` エラーを専用処理
- エラーの `cause` に適切なメタデータを設定

### 3. フロントエンドのエラールーティング
- `error.ts` でエラータイプを認識してi18nキーを構築
- 既存の `voice_limit_reached` と同様の処理フローを実装

### 4. UIでの表示対応
- `voice_clone.vue` のエラーハンドラーを拡張
- 「詳細を見る」ボタンをクリックでElevenLabsのサブスクリプション画面を開く

## 動作
- ✅ APIから返ってきた生のエラーメッセージは表示されない
- ✅ 日本語/英語で適切なメッセージが表示される
- ✅ アクションボタン（「詳細を見る」/ "View Details"）が表示される
- ✅ ボタンクリックで `https://elevenlabs.io/app/subscription` が開く

## テスト方法
1. ElevenLabsの無料プランまたは音声クローン非対応プランで音声クローンを実行
2. エラーが国際化されたメッセージで表示されることを確認
3. 「詳細を見る」ボタンでサブスクリプション画面が開くことを確認


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for displaying a notification when instant voice cloning is unavailable. Users will now see localized messages (English and Japanese) informing them about access restrictions, with action prompts and links for subscription or plan information.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->