### PR TITLE
fix: Improve voice clone UI - truncate long filenames and stop audio on page navigation

### DIFF
--- a/src/renderer/pages/voice_clone.vue
+++ b/src/renderer/pages/voice_clone.vue
@@ -119,7 +119,7 @@
                 :disabled="uploadDialog.uploading"
               />
               <div v-if="uploadDialog.fileName" class="space-y-2">
-                <div class="text-primary font-medium">{{ uploadDialog.fileName }}</div>
+                <p class="text-primary line-clamp-3 text-sm font-medium break-all">{{ uploadDialog.fileName }}</p>
                 <p class="text-muted-foreground text-xs">
                   {{ t("voiceClone.fileRequirements", { maxSizeMB: 10 }) }}
                 </p>
@@ -179,7 +179,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted, computed } from "vue";
+import { ref, onMounted, onBeforeUnmount, computed } from "vue";
 import { Mic, Loader2, Play, Pause, Pencil, Plus, Trash2 } from "lucide-vue-next";
 import { useI18n } from "vue-i18n";
 
@@ -459,5 +459,15 @@ const confirmDelete = async () => {
 onMounted(() => {
   audioElement.value = new Audio();
   loadClonedVoices();
+});
+
+onBeforeUnmount(() => {
+  // Stop audio playback when leaving the page
+  if (audioElement.value) {
+    audioElement.value.pause();
+    audioElement.value.src = "";
+  }
+  // Reset playing state
+  playingVoiceId.value = null;
 });
 </script>


### PR DESCRIPTION
## 概要
Voice Clone機能のUIを2点改善しました。

## 変更内容
- 長いファイル名の表示問題を修正
  - アップロードダイアログで長いファイル名が表示されるとレイアウトが崩れる問題を修正

- ページ遷移時の音声自動停止機能を追加
  - Voice Cloneページでサンプル音声を再生中に別のページに移動した場合、音声が再生し続ける問題を修正

## 変更前
<img width="665" height="489" alt="image" src="https://github.com/user-attachments/assets/f76d6867-973e-49cb-b27c-e3bd0a5422f0" />

## 変更後
<img width="628" height="492" alt="image" src="https://github.com/user-attachments/assets/059e9c9c-37e7-4f27-a44b-dbc41042e420" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed audio playback continuing after leaving the voice clone page; audio now properly stops, sources clear, and playback state resets when navigating away.

* **UI/UX Improvements**
  * Enhanced the display of uploaded file names with improved text formatting and line-clamping for better visual presentation and readability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->