### PR TITLE
Apply last selected beat type only to newly inserted selectors

### DIFF
--- a/src/renderer/pages/project/script_editor.vue
+++ b/src/renderer/pages/project/script_editor.vue
@@ -73,11 +73,7 @@
         </p>
         <div class="mx-auto space-y-2">
           <div class="px-2 py-1">
-            <BeatSelector
-              @emitBeat="(beat, beatType) => addBeat(beat, -1, beatType)"
-              buttonKey="insert"
-              :isPro="globalStore.userIsPro"
-            />
+            <BeatSelector @emitBeat="(beat) => addBeat(beat, -1)" buttonKey="insert" :isPro="globalStore.userIsPro" />
           </div>
 
           <TransitionGroup
@@ -134,10 +130,10 @@
               </div>
               <div class="px-4 pt-2">
                 <BeatSelector
-                  @emitBeat="(beat, beatType) => addBeat(beat, index, beatType)"
+                  @emitBeat="(beat) => addBeat(beat, index)"
                   buttonKey="insert"
                   :isPro="globalStore.userIsPro"
-                  :lastSelectedBeatType="beat?.id === lastInsertedBeatId ? lastSelectedBeatType : undefined"
+                  :currentBeatType="getBeatType(beat)"
                 />
               </div>
             </div>
@@ -199,11 +195,7 @@
 
         <div class="mx-auto space-y-2">
           <div class="px-2 py-1">
-            <BeatSelector
-              @emitBeat="(beat, beatType) => addBeat(beat, -1, beatType)"
-              buttonKey="insert"
-              :isPro="globalStore.userIsPro"
-            />
+            <BeatSelector @emitBeat="(beat) => addBeat(beat, -1)" buttonKey="insert" :isPro="globalStore.userIsPro" />
           </div>
 
           <TransitionGroup
@@ -274,10 +266,10 @@
               </div>
               <div class="px-4 pt-2">
                 <BeatSelector
-                  @emitBeat="(beat, beatType) => addBeat(beat, index, beatType)"
+                  @emitBeat="(beat) => addBeat(beat, index)"
                   buttonKey="insert"
                   :isPro="globalStore.userIsPro"
-                  :lastSelectedBeatType="beat?.id === lastInsertedBeatId ? lastSelectedBeatType : undefined"
+                  :currentBeatType="getBeatType(beat)"
                 />
               </div>
             </div>
@@ -371,7 +363,7 @@ import { MulmoError } from "../../../types";
 import { arrayPositionUp, arrayInsertAfter } from "@/lib/array";
 import { SCRIPT_EDITOR_TABS, type ScriptEditorTab } from "../../../shared/constants";
 
-import { setRandomBeatId } from "@/lib/beat_util";
+import { getBeatType, setRandomBeatId } from "@/lib/beat_util";
 import { projectApi } from "@/lib/project_api";
 import { useMulmoGlobalStore, useMulmoScriptHistoryStore } from "@/store";
 import { notifySuccess } from "@/lib/notification";
@@ -414,8 +406,6 @@ const globalStore = useMulmoGlobalStore();
 const mulmoScriptHistoryStore = useMulmoScriptHistoryStore();
 
 const currentTab = ref<ScriptEditorTab>(props.scriptEditorActiveTab || SCRIPT_EDITOR_TABS.TEXT);
-const lastSelectedBeatType = ref<string | undefined>(undefined);
-const lastInsertedBeatId = ref<string | undefined>(undefined);
 
 const handleUpdateScriptEditorActiveTab = (tab: ScriptEditorTab) => {
   /*
@@ -423,9 +413,6 @@ const handleUpdateScriptEditorActiveTab = (tab: ScriptEditorTab) => {
     return;
   }
   */
-  if (tab !== currentTab.value) {
-    lastInsertedBeatId.value = undefined;
-  }
   emit("formatAndPushHistoryMulmoScript");
   emit("update:scriptEditorActiveTab", tab);
 };
@@ -474,7 +461,6 @@ watch(
   () => props.scriptEditorActiveTab,
   (newTab) => {
     if (newTab && newTab !== currentTab.value) {
-      lastInsertedBeatId.value = undefined;
       currentTab.value = newTab;
     }
   },
@@ -616,16 +602,11 @@ const changeBeat = (beat: MulmoBeat, index: number) => {
   });
 };
 
-const addBeat = (beat: MulmoBeat, index: number, beatType?: string) => {
-  if (beatType) {
-    lastSelectedBeatType.value = beatType;
-  }
+const addBeat = (beat: MulmoBeat, index: number) => {
   beat.speaker = props.mulmoScript?.speechParams?.speakers
     ? MulmoPresentationStyleMethods.getDefaultSpeaker(props.mulmoScript)
     : defaultSpeaker;
-  const beatWithId = setRandomBeatId(beat);
-  lastInsertedBeatId.value = beatWithId.id;
-  const newBeats = arrayInsertAfter(props.mulmoScript.beats, index, beatWithId);
+  const newBeats = arrayInsertAfter(props.mulmoScript.beats, index, setRandomBeatId(beat));
   emit("updateMulmoScriptAndPushToHistory", {
     ...props.mulmoScript,
     beats: newBeats,

--- a/src/renderer/pages/project/script_editor/beat_selector.vue
+++ b/src/renderer/pages/project/script_editor/beat_selector.vue
@@ -26,7 +26,6 @@ interface Props {
   buttonKey: string;
   currentBeatType?: string;
   isPro: boolean;
-  lastSelectedBeatType?: string;
 }
 const props = defineProps<Props>();
 
@@ -38,45 +37,36 @@ const selectedBeat = ref(0);
 const templates = computed(() => {
   return props.isPro ? beatTemplates : simpleTemplates;
 });
-const syncSelectedBeat = (useDefault: boolean) => {
-  // currentBeatTypeが優先（beat変更時）
+const initSelectedBeat = () => {
   if (props.currentBeatType) {
     const index = templates.value.findIndex((beat) => beat.key === props.currentBeatType);
-    if (index !== -1) {
-      selectedBeat.value = index;
-    }
-    return;
-  }
-  if (!useDefault) {
-    return;
-  }
-  // 次にlastSelectedBeatType（追加ボタン用）
-  if (props.lastSelectedBeatType) {
-    const index = templates.value.findIndex((beat) => beat.key === props.lastSelectedBeatType);
     if (index !== -1) {
       selectedBeat.value = index;
       return;
     }
   }
-  // デフォルトは0
   selectedBeat.value = 0;
 };
 
 onMounted(() => {
-  syncSelectedBeat(true);
+  initSelectedBeat();
 });
 
 watch([() => props.currentBeatType, templates], () => {
-  syncSelectedBeat(false);
+  initSelectedBeat();
 });
 
 const disableChange = computed(() => {
-  return props.currentBeatType && props.currentBeatType === templates.value[selectedBeat.value]?.key;
+  return (
+    props.buttonKey === "change" &&
+    props.currentBeatType &&
+    props.currentBeatType === templates.value[selectedBeat.value]?.key
+  );
 });
 
 const emitBeat = () => {
   const template = templates.value[selectedBeat.value];
   const beat = { ...template.beat };
-  emit("emitBeat", beat, template.key);
+  emit("emitBeat", beat);
 };
 </script>


### PR DESCRIPTION
## 概要
- 直前に選んだビートタイプの初期選択を、新規追加された BeatSelector に適用

## 変更内容
- `lastSelectedBeatType` を追加し、直前に選んだビートタイプを保持
- 直近で追加したビートIDを記録し、該当ボタンにのみ `lastSelectedBeatType` を渡す
- タブ移動時は直近追加IDをクリアして既存ボタンの表示が変わらないようにした

## 影響範囲
- `src/renderer/pages/project/script_editor.vue`
- `src/renderer/pages/project/script_editor/beat_selector.vue`
- `docs/plans/beat-selector-default-selection.md`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Beat selector now remembers the last beat type you chose and automatically applies it to newly inserted beat buttons, improving insertion consistency without changing existing buttons across tabs.
* **Documentation**
  * Added documentation detailing the new default-selection behavior and verification steps.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->