### PR TITLE
fix: handle corrupted MulmoScript gracefully

### DIFF
--- a/src/renderer/pages/project.vue
+++ b/src/renderer/pages/project.vue
@@ -409,12 +409,12 @@ onMounted(async () => {
     updateMultiLingual();
     projectMetadata.value = await projectApi.getProjectMetadata(projectId.value);
     const data = await projectApi.getProjectMulmoScript(projectId.value);
-    if (data.beats) {
-      data.beats.map(setRandomBeatId);
+    const script = data ?? { beats: [], lang: globalStore.settings.APP_LANGUAGE };
+    if (script.beats) {
+      script.beats.map(setRandomBeatId);
     }
-    mulmoScriptHistoryStore.initMulmoScript(data, globalStore.settings.APP_LANGUAGE);
-    // mulmoScriptHistoryStore.lang
-    downloadAudioFiles(projectId.value, data.lang ?? globalStore.settings.APP_LANGUAGE);
+    mulmoScriptHistoryStore.initMulmoScript(script, globalStore.settings.APP_LANGUAGE);
+    downloadAudioFiles(projectId.value, script.lang ?? globalStore.settings.APP_LANGUAGE);
     downloadImageFiles(projectId.value);
   } catch (error) {
     console.error("Failed to load project:", error);


### PR DESCRIPTION
## Summary
- Fix crash when opening projects with corrupted or null script.json
- Instead of redirecting to dashboard, initialize with empty beats array

## Problem
When `script.json` is corrupted or null, the app crashes with:
```
TypeError: Cannot read properties of null (reading 'beats')
```
And redirects user to dashboard, making it impossible to recover the project.

## Solution
```typescript
const script = data ?? { beats: [], lang: globalStore.settings.APP_LANGUAGE };
```
Initialize with empty beats array when data is null, allowing users to continue working.

## Test plan
- [ ] Open a project with corrupted/missing script.json
- [ ] Verify project opens with empty beats instead of crashing
- [ ] Verify normal projects still load correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved project editor stability by implementing robust fallback mechanisms for project configuration and language settings, preventing potential errors and ensuring reliable operation during project initialization and audio processing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->