### PR TITLE
feat: add caption split toggle to style settings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -197,6 +197,62 @@ export class SecureKeyStore {
 2. Main process reads files and returns as ArrayBuffers
 3. Renderer displays assets in UI
 
+## Reka UI Component Patterns
+
+This project uses Reka UI (formerly Radix Vue) for UI components. Important API conventions:
+
+### Switch Component
+
+The Switch component uses `model-value` pattern, NOT `checked`:
+
+```vue
+<!-- CORRECT -->
+<Switch
+  :model-value="isEnabled"
+  @update:model-value="handleToggle"
+/>
+
+<!-- WRONG - will not work -->
+<Switch
+  :checked="isEnabled"
+  @update:checked="handleToggle"
+/>
+```
+
+### General Reka UI Emit Patterns
+
+- Most Reka UI components use `update:model-value` (kebab-case in template)
+- In TypeScript types, it appears as `update:modelValue` (camelCase)
+- Always check the component's emit types when unsure:
+  ```typescript
+  // Example: SwitchRootEmits
+  type SwitchRootEmits = {
+    'update:modelValue': [payload: boolean];
+  };
+  ```
+
+### Common Components and Their Value Props
+
+| Component | Value Prop | Event |
+|-----------|------------|-------|
+| Switch | `model-value` | `@update:model-value` |
+| Select | `model-value` | `@update:model-value` |
+| Checkbox | `model-value` | `@update:model-value` |
+| RadioGroup | `model-value` | `@update:model-value` |
+
+### Vue emit Pattern
+
+When creating custom components, follow Vue's standard pattern:
+
+```typescript
+const emit = defineEmits<{
+  update: [value: SomeType];  // Custom event
+}>();
+
+// Call with:
+emit("update", newValue);
+```
+
 ## Important Patterns
 
 1. **Always use absolute paths** in main process file operations

--- a/src/renderer/i18n/en.ts
+++ b/src/renderer/i18n/en.ts
@@ -904,6 +904,8 @@ const lang = {
       noLanguage: "None",
       styles: "Styles",
       stylesDescription: "Enter CSS styles (one per line)",
+      captionSplit: "Caption Split",
+      captionSplitDescription: "Split captions at punctuation marks (. ! ? etc.)",
     },
     textSlideParams: {
       title: "Common Slide Parameters",

--- a/src/renderer/i18n/ja.ts
+++ b/src/renderer/i18n/ja.ts
@@ -904,6 +904,8 @@ const lang = {
       noLanguage: "なし",
       styles: "スタイル",
       stylesDescription: "CSSスタイルを入力してください(1行に1つずつ)",
+      captionSplit: "字幕分割",
+      captionSplitDescription: "句読点で字幕を分割します（。.！!？?など）",
     },
     textSlideParams: {
       title: "スライド共通設定",


### PR DESCRIPTION
## Summary

- Add Switch toggle to caption params for enabling/disabling caption split
- When enabled, sets `captionSplit: "estimate"` and `textSplit` with universal delimiters
- Universal delimiters support all languages: `。．.！!？?；;\n`
- Add i18n translations for caption split feature (ja/en)
- Document Reka UI component patterns in CLAUDE.md

## Technical Notes

Fixed an issue where Reka UI Switch component wasn't responding to toggle:
- Reka UI Switch uses `model-value` and `@update:model-value`, NOT `checked` and `@update:checked`
- Added documentation to CLAUDE.md to prevent future issues

## Test plan

- [ ] Toggle caption split ON → verify `captionSplit: "estimate"` and `textSplit` with delimiters are added to JSON
- [ ] Toggle caption split OFF → verify `captionSplit` and `textSplit` are removed from JSON
- [ ] Verify toggle is disabled when no caption language is selected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Caption Split option to caption parameters. When enabled, captions are automatically split at punctuation marks (periods, exclamation marks, question marks, etc.) for improved readability.

* **Localization**
  * Added English and Japanese translations for the new Caption Split feature.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->