### PR TITLE
feat: add editable delimiters for caption split feature

### DIFF
--- a/src/renderer/i18n/en.ts
+++ b/src/renderer/i18n/en.ts
@@ -906,6 +906,7 @@ const lang = {
       stylesDescription: "Enter CSS styles (one per line)",
       captionSplit: "Caption Split",
       captionSplitDescription: "Split captions at punctuation marks (. ! ? etc.)",
+      delimitersDescription: "Characters that split captions (one per line, \\n for newline)",
     },
     textSlideParams: {
       title: "Common Slide Parameters",

--- a/src/renderer/i18n/ja.ts
+++ b/src/renderer/i18n/ja.ts
@@ -906,6 +906,7 @@ const lang = {
       stylesDescription: "CSSスタイルを入力してください(1行に1つずつ)",
       captionSplit: "字幕分割",
       captionSplitDescription: "句読点で字幕を分割します（。.！!？?など）",
+      delimitersDescription: "字幕を分割する文字（1行に1つ、改行は\\nと入力）",
     },
     textSlideParams: {
       title: "スライド共通設定",


### PR DESCRIPTION
## 概要
- 字幕分割の説明文を常時表示に変更
- 区切り文字（delimiters）を編集可能なTextareaで表示
- スタイルタブとJSONの双方向同期をサポート
- 改行文字は `\n` として表示・入力可能

disable 
<img width="419" height="104" alt="image" src="https://github.com/user-attachments/assets/8df4addb-f69c-4fd5-836c-372cd064eb3d" />

enable
<img width="436" height="346" alt="image" src="https://github.com/user-attachments/assets/c83fbdb6-3f3c-466e-9716-dd589a5de220" />


## 変更内容
- `caption_params.vue`: 区切り文字編集UIを追加
- `en.ts` / `ja.ts`: 区切り文字説明文の翻訳を追加

## 技術的な詳細
- 改行文字 `\n` は UI 上では `\\n` としてエスケープ表示
- 保存時に `\\n` を実際の改行文字に変換
- CSS styles と同じ同期パターンを採用

## テスト方法
1. プロジェクトを開き、字幕パラメータを表示
2. 字幕分割トグルをON → 区切り文字が表示されることを確認
3. Textareaで区切り文字を編集 → JSONが更新されることを確認
4. JSONのdelimitersを直接編集 → Textareaが更新されることを確認

関連PR #1515 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added customizable delimiter configuration for caption splitting. Users can now define custom characters to split captions, with support for newline characters. The feature is available when caption splitting is enabled.
  
* **Documentation**
  * Updated localization strings in English and Japanese to describe the new delimiter functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->