### PR TITLE
chore: update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,6 +85,9 @@
     "vue-tsc": "^3.2.4",
     "yaml-eslint-parser": "^2.0.0"
   },
+  "resolutions": {
+    "unicorn-magic": "0.2.0"
+  },
   "dependencies": {
     "@elevenlabs/elevenlabs-js": "^2.35.0",
     "@graphai/llm_agents": "^2.0.14",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10262,10 +10262,10 @@ unicode-trie@^2.0.0:
     pako "^0.2.5"
     tiny-inflate "^1.0.0"
 
-unicorn-magic@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/unicorn-magic/-/unicorn-magic-0.3.0.tgz#4efd45c85a69e0dd576d25532fbfa22aa5c8a104"
-  integrity sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==
+unicorn-magic@0.2.0, unicorn-magic@^0.3.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/unicorn-magic/-/unicorn-magic-0.2.0.tgz#623c1d38a296aac5e1c4bde4618c4c93a6f4741d"
+  integrity sha512-q83y+/QtXrbKX1jYY+bdQROAbZj6EeSP+Plv0cYZBMPfirSaEvnnhMwRk2WH4n5XkNCQHygAiwTVNpvw3I1dCg==
 
 unique-filename@^2.0.0:
   version "2.0.1"


### PR DESCRIPTION
## Summary

依存パッケージのバージョン更新。

### 主な変更

| パッケージ | 変更 | 種別 |
|---|---|---|
| `@tato30/vue-pdf` | 1.11.5 → **2.0.0** | **メジャー** |
| `electron` | 40.2.1 → 40.3.0 | マイナー |
| `@elevenlabs/elevenlabs-js` | 2.34.0 → 2.35.0 | マイナー |
| `vue` | 3.5.27 → 3.5.28 | パッチ |
| `@vueuse/core` | 14.2.0 → 14.2.1 | パッチ |
| `@typescript-eslint/*` | 8.54.0 → 8.55.0 | マイナー |
| `@types/node` | 25.2.2 → 25.2.3 | パッチ |
| `eslint-plugin-sonarjs` | 3.0.6 → 3.0.7 | パッチ |

### @tato30/vue-pdf v2.0.0 互換性調査

v1 → v2 はメジャーバージョンアップだが、本プロジェクトへの影響は **低い**。

**本プロジェクトの使用箇所** (`src/renderer/components/product/tabs/pdf_tab.vue`):
- `<VuePDF :pdf="..." :page="..." :scale="0.8" :fit-parent="true" />`
- `const { pdf, pages } = usePDF(pdfBuffer)`

**v2.0.0 の主な破壊的変更と影響:**

| 変更点 | 影響 |
|---|---|
| UMD ビルド削除（ESM のみ） | ✅ 影響なし（Vite で ESM 使用） |
| `useTemplateRef()` 使用（Vue 3.5+ 必須） | ✅ 影響なし（Vue 3.5.28 使用中） |
| `usePDF` API | ✅ 変更なし |
| VuePDF props/events | ✅ 既存 props 変更なし（新規追加のみ） |
| DOM 構造変更（canvas が div でラップ） | ⚠️ カスタム CSS があれば確認必要 |
| pdfjs-dist 5.4.296 → 5.4.624 | ✅ マイナー更新 |

**結論**: 使用している props (`pdf`, `page`, `scale`, `fit-parent`) と composable (`usePDF`) は v2 でも完全互換。PDF タブの表示に問題がないか目視確認を推奨。

### Electron 40.3.0

40.2.1 → 40.3.0 のマイナーアップデート。

## Test plan

- [ ] CI が全て通ること
- [ ] PDF タブで PDF が正しく表示されること（vue-pdf v2 の DOM 構造変更の影響確認）
- [ ] PDF のページ送り・ダウンロードが動作すること
- [ ] アプリの起動・基本操作に問題がないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)