### PR TITLE
Add readClipboardText to preload and migrate QA tests to IPC

### DIFF
--- a/src/main/ipc_handler.ts
+++ b/src/main/ipc_handler.ts
@@ -70,6 +70,10 @@ export const registerIPCHandler = () => {
     clipboard.writeText(text ?? "");
   });
 
+  ipcMain.handle("readClipboardText", () => {
+    return clipboard.readText();
+  });
+
   ipcMain.handle("openExternal", async (_event: IpcMainInvokeEvent, url: string) => {
     await shell.openExternal(url);
   });

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -32,6 +32,7 @@ export interface ElectronAPI {
     set: (settings: unknown) => Promise<unknown>;
   };
   writeClipboardText: (text: string) => Promise<unknown>;
+  readClipboardText: () => Promise<string>;
   openExternal: (url: string) => Promise<void>;
   onNavigate: (callback: (path: string) => void) => void;
 }
@@ -67,6 +68,7 @@ const api: ElectronAPI = {
     set: (settings: unknown) => ipcRenderer.invoke("settings:set", settings),
   },
   writeClipboardText: (text: string) => ipcRenderer.invoke("writeClipboardText", text),
+  readClipboardText: () => ipcRenderer.invoke("readClipboardText"),
   openExternal: (url: string) => ipcRenderer.invoke("openExternal", url),
   onNavigate: (callback: (path: string) => void) => {
     ipcRenderer.on("navigate", (_, path) => callback(path));

--- a/test/manual_no_api_electron_upgrade_qa.ts
+++ b/test/manual_no_api_electron_upgrade_qa.ts
@@ -245,7 +245,7 @@ async function testMonacoEditor(page: Page) {
     await page.keyboard.press(copyKey);
     await page.waitForTimeout(200);
 
-    const originalJson = await page.evaluate(() => navigator.clipboard.readText());
+    const originalJson = await page.evaluate(() => window.electronAPI.readClipboardText());
 
     let parsed: Record<string, unknown>;
     try {
@@ -261,7 +261,7 @@ async function testMonacoEditor(page: Page) {
 
     // --- Helper: select all, paste JSON, wait for save ---
     const pasteJson = async (json: string) => {
-      await page.evaluate((text) => navigator.clipboard.writeText(text), json);
+      await page.evaluate((text) => window.electronAPI.writeClipboardText(text), json);
       await page.waitForTimeout(200);
       await page.keyboard.press(selectAllKey);
       await page.waitForTimeout(200);
@@ -276,7 +276,7 @@ async function testMonacoEditor(page: Page) {
       await page.waitForTimeout(200);
       await page.keyboard.press(copyKey);
       await page.waitForTimeout(200);
-      const text = await page.evaluate(() => navigator.clipboard.readText());
+      const text = await page.evaluate(() => window.electronAPI.readClipboardText());
       try {
         return JSON.parse(text);
       } catch {

--- a/test/manual_no_api_speech_params_qa.ts
+++ b/test/manual_no_api_speech_params_qa.ts
@@ -223,7 +223,7 @@ async function readEditorJson(page: Page): Promise<Record<string, unknown> | nul
   await page.waitForTimeout(200);
   await page.keyboard.press(copyKey);
   await page.waitForTimeout(200);
-  const text = await page.evaluate(() => navigator.clipboard.readText());
+  const text = await page.evaluate(() => window.electronAPI.readClipboardText());
   try {
     return JSON.parse(text);
   } catch {
@@ -238,7 +238,7 @@ async function writeEditorJson(page: Page, json: Record<string, unknown>): Promi
   await page.waitForTimeout(300);
   await page.keyboard.press(selectAllKey);
   await page.waitForTimeout(200);
-  await page.evaluate((t) => navigator.clipboard.writeText(t), JSON.stringify(json, null, 2));
+  await page.evaluate((t) => window.electronAPI.writeClipboardText(t), JSON.stringify(json, null, 2));
   await page.waitForTimeout(200);
   await page.keyboard.press(pasteKey);
   await page.waitForTimeout(2000);

--- a/test/manual_no_api_vertex_ai_qa.ts
+++ b/test/manual_no_api_vertex_ai_qa.ts
@@ -337,7 +337,7 @@ async function readEditorJson(page: Page): Promise<Record<string, unknown> | nul
   await page.waitForTimeout(200);
   await page.keyboard.press(copyKey);
   await page.waitForTimeout(200);
-  const text = await page.evaluate(() => navigator.clipboard.readText());
+  const text = await page.evaluate(() => window.electronAPI.readClipboardText());
   try {
     return JSON.parse(text);
   } catch {
@@ -353,7 +353,7 @@ async function writeEditorJson(page: Page, json: Record<string, unknown>): Promi
   await page.keyboard.press(selectAllKey);
   await page.waitForTimeout(200);
   const newText = JSON.stringify(json, null, 2);
-  await page.evaluate((t) => navigator.clipboard.writeText(t), newText);
+  await page.evaluate((t) => window.electronAPI.writeClipboardText(t), newText);
   await page.waitForTimeout(200);
   await page.keyboard.press(pasteKey);
   // Wait for Monaco to finish internal operations (diagnostics, validation)


### PR DESCRIPTION
## 概要

Electron 40 で非推奨となった `navigator.clipboard` の renderer 直接アクセスを IPC 経由に移行。

## 変更内容

### preload / IPC handler
- `readClipboardText` を preload API に追加（既存の `writeClipboardText` と対になる read 側）
- main プロセスに `readClipboardText` IPC ハンドラを追加

### QA テスト移行（3ファイル）
- `navigator.clipboard.readText()` → `window.electronAPI.readClipboardText()`
- `navigator.clipboard.writeText()` → `window.electronAPI.writeClipboardText()`

対象ファイル:
- `test/manual_no_api_electron_upgrade_qa.ts`
- `test/manual_no_api_speech_params_qa.ts`
- `test/manual_no_api_vertex_ai_qa.ts`

## テスト結果

| テスト | 結果 |
|--------|------|
| `manual_no_api_electron_upgrade_qa.ts` | 25/25 PASS |
| `manual_no_api_speech_params_qa.ts` | 126/126 PASS |
| `manual_no_api_vertex_ai_qa.ts` | 99/99 PASS |

Closes #1543

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Implemented a new Electron-native clipboard access system to enhance reliability and consistency of clipboard operations throughout the application, providing a more robust foundation for clipboard functionality.
  * Updated internal testing infrastructure and quality assurance processes to fully integrate with and support the new clipboard system implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->