### PR TITLE
Fix lint warnings in test files

### DIFF
--- a/test/automated_serial_generation_e2e_test.ts
+++ b/test/automated_serial_generation_e2e_test.ts
@@ -144,6 +144,7 @@ async function createProject(page: Page, jsonFile: string, step: { value: number
     console.error(`[DEBUG] JSON validation FAILED:`, parseError);
     throw new Error(
       `Invalid JSON in ${jsonFile}: ${parseError instanceof Error ? parseError.message : String(parseError)}`,
+      { cause: parseError },
     );
   }
 
@@ -690,6 +691,7 @@ async function runGenerationE2ETest(): Promise<void> {
         if (attempts === CONFIG.CDP_MAX_ATTEMPTS) {
           throw new Error(
             `Failed to connect to CDP after ${CONFIG.CDP_MAX_ATTEMPTS} attempts: ${error instanceof Error ? error.message : String(error)}`,
+            { cause: error },
           );
         }
         if (attempts === 1) {

--- a/test/manual_no_api_electron_upgrade_qa.ts
+++ b/test/manual_no_api_electron_upgrade_qa.ts
@@ -61,6 +61,7 @@ async function connectCDP(): Promise<Browser> {
       if (attempts === CONFIG.CDP_MAX_ATTEMPTS) {
         throw new Error(
           `Failed to connect after ${CONFIG.CDP_MAX_ATTEMPTS} attempts: ${error instanceof Error ? error.message : String(error)}`,
+          { cause: error },
         );
       }
       if (attempts === 1) {
@@ -567,7 +568,7 @@ async function testExternalLinkButton(page: Page) {
   console.log("");
 
   const resources: { browser: Browser | null } = { browser: null };
-  let exitCode = 1;
+  let exitCode: number;
 
   try {
     resources.browser = await connectCDP();

--- a/test/manual_no_api_vertex_ai_qa.ts
+++ b/test/manual_no_api_vertex_ai_qa.ts
@@ -91,6 +91,7 @@ async function connectCDP(): Promise<Browser> {
       if (attempts === CONFIG.CDP_MAX_ATTEMPTS) {
         throw new Error(
           `Failed to connect after ${CONFIG.CDP_MAX_ATTEMPTS} attempts: ${error instanceof Error ? error.message : String(error)}`,
+          { cause: error },
         );
       }
       if (attempts === 1) {
@@ -1969,7 +1970,7 @@ async function testConsoleHealth(monitor: ConsoleMonitor) {
   console.log("========================================\n");
 
   const resources: { browser: Browser | null } = { browser: null };
-  let exitCode = 1;
+  let exitCode: number;
 
   try {
     resources.browser = await connectCDP();

--- a/test/manual_run_switch_language.ts
+++ b/test/manual_run_switch_language.ts
@@ -37,6 +37,7 @@ async function testChangeLanguage(targetLanguage: "en" | "ja"): Promise<void> {
         if (attempts === CONFIG.CDP_MAX_ATTEMPTS) {
           throw new Error(
             `Failed to connect to CDP after ${CONFIG.CDP_MAX_ATTEMPTS} attempts: ${error instanceof Error ? error.message : String(error)}`,
+            { cause: error },
           );
         }
         if (attempts === 1) {


### PR DESCRIPTION
## 概要

`yarn lint` で検出される `test/` 配下の 7 件の警告を解消する。

## 修正内容

### `preserve-caught-error` (6 件)

catch した error を新しい `Error` に包み直す際、元の error を失わないよう `{ cause: error }` を第2引数に追加。

- `test/automated_serial_generation_e2e_test.ts:145` — JSON パース失敗時
- `test/automated_serial_generation_e2e_test.ts:691` — CDP 接続リトライ失敗時
- `test/manual_no_api_electron_upgrade_qa.ts:62` — CDP 接続リトライ失敗時
- `test/manual_no_api_vertex_ai_qa.ts:92` — CDP 接続リトライ失敗時
- `test/manual_run_switch_language.ts:38` — CDP 接続リトライ失敗時

### `no-useless-assignment` (2 件)

`exitCode` の初期値 `1` が常に try/catch 内で再代入されるため、初期値を削除して `let exitCode: number;` に変更。

- `test/manual_no_api_electron_upgrade_qa.ts:570`
- `test/manual_no_api_vertex_ai_qa.ts:1972`

## 動作確認

- `yarn lint` で `test/` 配下の警告 7 件すべて解消を確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced error handling and diagnostics throughout test infrastructure by improving error chaining to provide more detailed root cause information.
  * Updated error propagation in multiple test suites to better capture and report original error details when connection and parsing failures occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->