### PR TITLE
Add `mulmoclaude` dev starter (Vite + Express) and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,22 @@ yarn install
 yarn run start
 ```
 
+
+## 🧪 Vue + Express Development Mode (mulmoclaude)
+
+```bash
+npx mulmoclaude
+```
+
+- Vue (Vite): `http://127.0.0.1:5173`
+- Express API: `http://127.0.0.1:3001` (`/health`, `/api/message`, `/api/echo`)
+
+You can override ports with environment variables if needed.
+
+```bash
+MULMOCLAUDE_VITE_PORT=5174 MULMOCLAUDE_EXPRESS_PORT=3002 npx mulmoclaude
+```
+
 ## Build Application
 
 There are two ways to build the application:

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "type-check:main": "tsc --noEmit -p ./tsconfig.main.json",
     "type-check:renderer": "tsc --noEmit -p ./tsconfig.renderer.json",
     "i18n:check": "npx tsx scripts/check-i18n.ts",
-    "i18n:translate": "npx tsx scripts/translate-i18n.ts"
+    "i18n:translate": "npx tsx scripts/translate-i18n.ts",
+    "mulmoclaude": "node scripts/mulmoclaude.mjs"
   },
   "keywords": [],
   "author": {
@@ -134,6 +135,10 @@
     "vue-router": "^5.0.4",
     "vue-sonner": "^2.0.9",
     "yauzl": "^3.2.1",
-    "zod": "^4.3.6"
+    "zod": "^4.3.6",
+    "express": "^5.1.0"
+  },
+  "bin": {
+    "mulmoclaude": "./scripts/mulmoclaude.mjs"
   }
 }

--- a/scripts/dev-express-server.mjs
+++ b/scripts/dev-express-server.mjs
@@ -1,0 +1,23 @@
+import express from "express";
+
+const app = express();
+const host = process.env.MULMOCLAUDE_EXPRESS_HOST ?? "127.0.0.1";
+const port = Number(process.env.MULMOCLAUDE_EXPRESS_PORT ?? 3001);
+
+app.use(express.json());
+
+app.get("/health", (_req, res) => {
+  res.json({ ok: true, service: "mulmoclaude-express" });
+});
+
+app.get("/api/message", (_req, res) => {
+  res.json({ message: "Hello from Express API" });
+});
+
+app.post("/api/echo", (req, res) => {
+  res.json({ body: req.body ?? null });
+});
+
+app.listen(port, host, () => {
+  console.log(`[mulmoclaude] Express server running at http://${host}:${port}`);
+});

--- a/scripts/mulmoclaude.mjs
+++ b/scripts/mulmoclaude.mjs
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const showHelp = process.argv.includes("--help") || process.argv.includes("-h");
+if (showHelp) {
+  console.log(`mulmoclaude: Vue (Vite) + Express dev starter\n\nUsage:\n  npx mulmoclaude\n\nEnvironment variables:\n  MULMOCLAUDE_VITE_PORT      (default: 5173)\n  MULMOCLAUDE_EXPRESS_PORT   (default: 3001)\n  MULMOCLAUDE_EXPRESS_HOST   (default: 127.0.0.1)`);
+  process.exit(0);
+}
+
+const children = [];
+
+const spawnService = (label, cmd, args, envExtra = {}) => {
+  const child = spawn(cmd, args, {
+    cwd: resolve(__dirname, ".."),
+    env: { ...process.env, ...envExtra },
+    stdio: ["inherit", "pipe", "pipe"],
+  });
+
+  child.stdout.on("data", (chunk) => {
+    process.stdout.write(`[${label}] ${chunk.toString()}`);
+  });
+
+  child.stderr.on("data", (chunk) => {
+    process.stderr.write(`[${label}] ${chunk.toString()}`);
+  });
+
+  child.on("exit", (code) => {
+    if (code && code !== 0) {
+      console.error(`[mulmoclaude] ${label} exited with code ${code}`);
+      shutdown(code);
+    }
+  });
+
+  children.push(child);
+};
+
+const shutdown = (code = 0) => {
+  for (const child of children) {
+    if (!child.killed) {
+      child.kill("SIGTERM");
+    }
+  }
+  process.exit(code);
+};
+
+process.on("SIGINT", () => shutdown(0));
+process.on("SIGTERM", () => shutdown(0));
+
+const vitePort = process.env.MULMOCLAUDE_VITE_PORT ?? "5173";
+const expressPort = process.env.MULMOCLAUDE_EXPRESS_PORT ?? "3001";
+
+console.log(`[mulmoclaude] Starting Vue(Vite) on :${vitePort} and Express on :${expressPort}`);
+
+spawnService("vue", "npx", ["vite", "--config", "vite.renderer.config.ts", "--host", "127.0.0.1", "--port", vitePort]);
+spawnService("express", "node", [resolve(__dirname, "dev-express-server.mjs")]);


### PR DESCRIPTION
### Motivation

- Provide a simple local development starter that runs the Vue (Vite) renderer and a lightweight Express API together.
- Make it easy to launch both services with a single CLI and configurable ports via environment variables.
- Document the new development mode and default endpoints in the `README.md`.

### Description

- Added an executable dev launcher `scripts/mulmoclaude.mjs` that spawns the Vite dev server and a local Express server and wires up graceful shutdown and a `--help` message.
- Added a minimal Express dev server in `scripts/dev-express-server.mjs` exposing `/health`, `/api/message`, and `/api/echo` endpoints.
- Updated `package.json` to add the `mulmoclaude` script, a `bin` entry for `mulmoclaude`, and added `express` to dependencies.
- Updated `README.md` with usage instructions for `npx mulmoclaude`, default ports, example endpoint URLs, and environment variable overrides.

### Testing

- No automated tests were executed as part of this change.
- Existing test scripts remain available (for example `yarn test` / `npm run test`) and were not modified by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7142c7384833385de4b090dc7459c)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `mulmoclaude` command to simultaneously run Vue/Vite development server and Express API server with default endpoints at localhost:5173 and localhost:3001.
  * Support for customizing ports via environment variables.

* **Documentation**
  * Added section documenting the new combined development mode, including startup instructions and available API endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->