### PR TITLE
feat: install MulmoErrorFormatter to use formatZodError

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "graphai": "^2.0.16",
     "monaco-editor": "^0.55.1",
     "monaco-yaml": "^5.5.0",
-    "mulmocast": "2.6.12",
+    "mulmocast": "2.6.13",
     "pinia": "^3.0.4",
     "punycode": "^2.3.1",
     "puppeteer": "24.43.0",

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -9,7 +9,10 @@ import log from "electron-log/main";
 import puppeteer from "puppeteer";
 import { GraphAILogger } from "graphai";
 
+import { setMulmoErrorFormatter } from "mulmocast";
+
 import { registerIPCHandler } from "./ipc_handler";
+import { formatZodError } from "./mulmo/error_utils";
 import * as projectManager from "./project_manager";
 import * as settingsManager from "./settings_manager";
 import { resolveTargetFromVersion } from "../shared/version";
@@ -326,4 +329,5 @@ app.on("activate", () => {
   }
 });
 
+setMulmoErrorFormatter(formatZodError);
 registerIPCHandler();

--- a/yarn.lock
+++ b/yarn.lock
@@ -7883,10 +7883,10 @@ mulmocast-vision@^1.0.9:
     pdfkit "^0.17.2"
     puppeteer "^24.39.1"
 
-mulmocast@2.6.12:
-  version "2.6.12"
-  resolved "https://registry.yarnpkg.com/mulmocast/-/mulmocast-2.6.12.tgz#f1672b380b5e90718caa6b7d411e153db03b62fd"
-  integrity sha512-NwUnTrNXa1f/qEQVn51/z/PHOv1vgkwQ2mxZO/lS/1dVObRoiQhl6xzqzFLMNi7srtSRefAzn+WFHRCrKFEWXw==
+mulmocast@2.6.13:
+  version "2.6.13"
+  resolved "https://registry.yarnpkg.com/mulmocast/-/mulmocast-2.6.13.tgz#743460e9964e377ffd7a4a2dd901a1dede421a50"
+  integrity sha512-VKcjRBGD49MIlvTID/PM5OiwlPkkyNpkHTX2lpm9vD2yqmaALkhboiEZrp2O+sspdxvJ3uQbuItzN1qKTkkB3A==
   dependencies:
     "@google-cloud/text-to-speech" "^6.4.1"
     "@google/genai" "^2.0.1"


### PR DESCRIPTION
## Summary

mulmocast v2.6.13 で導入された \`setMulmoErrorFormatter\` injection point に、既存の \`formatZodError\` ヘルパーを登録します。これにより mulmocast の \`initializeContextFromFiles\` 内で出る Zod validation エラーも、他箇所と同じ「1 issue = 1 行」のフォーマットになります。

## Before

\`\`\`
08:58:54.365 › Error: invalid MulmoScript Schema: /Users/.../script.json
 [
  {
    "code": "invalid_value",
    "values": ["openai", "google", ...],
    "path": ["speechParams", "speakers", "Announcer", "provider"],
    "message": "Invalid option: expected one of \"openai\"|\"google\"|..."
  },
  ...
]
\`\`\`

## After

\`\`\`
Error: invalid MulmoScript Schema: /Users/.../script.json
   - speechParams.speakers.Announcer.provider: Invalid option: expected one of "openai"|"google"|...
   - speechParams.speakers.Student.provider: Invalid option: expected one of "openai"|"google"|...
   - speechParams.speakers.Teacher.provider: Invalid option: expected one of "openai"|"google"|...
\`\`\`

## Changes

- \`package.json\` / \`yarn.lock\`: \`mulmocast\` 2.6.12 → 2.6.13
- \`src/main/main.ts\`: app 起動時に \`setMulmoErrorFormatter(formatZodError)\` を 1 回だけ登録

## Related

- mulmocast-cli の injection point 追加 PR: receptron/mulmocast-cli#1373
- 既存の \`formatZodError\` 実装: \`src/main/mulmo/error_utils.ts\` (PR #1632 でマージ済み)

## Test plan

- [x] \`yarn lint\` 0 errors
- [x] \`yarn type-check\` pass
- [ ] \`yarn start\` で壊れた script.json があるプロジェクトをスキャンし、ログが 1 行サマリーになることを確認

## User Prompt

> マージしたので、cliをpublish & releaseして。 → 続きを実行
> (formatter inject 実装 → publish 完了 → app 側で使う実装)

🤖 Generated with [Claude Code](https://claude.com/claude-code)