### PR TITLE
fix: resolve Windows Chromium path after Vite v8 migration

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -31,8 +31,12 @@ setupLogger();
 app.setName(BRAND.appName);
 
 // --- Runtime Puppeteer Patch ---
+// puppeteer の CJS エントリでは exports.launch = puppeteer.launch として関数参照を
+// スナップショットしており、default インスタンスの launch を差し替えても named export
+// 側には届かない。ESM の mulmocast 等が bundler 経由で `require("puppeteer").launch`
+// を直接呼ぶケースをカバーするため、両方を同時に上書きする。
 const originalLaunch = puppeteer.launch.bind(puppeteer);
-puppeteer.launch = function (options = {}) {
+const patchedLaunch: typeof puppeteer.launch = (options = {}) => {
   const finalOptions = {
     ...options,
     executablePath: options.executablePath || process.env.PUPPETEER_EXECUTABLE_PATH || undefined,
@@ -47,7 +51,12 @@ puppeteer.launch = function (options = {}) {
   return originalLaunch(finalOptions);
 };
 
-GraphAILogger.log("[PUPPETEER_PATCH] Runtime patch applied");
+puppeteer.launch = patchedLaunch;
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const puppeteerCJS = require("puppeteer") as { launch: typeof puppeteer.launch };
+puppeteerCJS.launch = patchedLaunch;
+
+GraphAILogger.log("[PUPPETEER_PATCH] Runtime patch applied (default + named export)");
 // end of Patch
 
 // Production環境でのChromiumパス設定

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1,7 +1,11 @@
+// 重要: puppeteer (および puppeteer を間接 import するモジュール = mulmocast 等) より「前」に
+// PUPPETEER_EXECUTABLE_PATH を確定させる必要がある。puppeteer の getConfiguration() が
+// import 時に env var を読んで configuration.executablePath にコピーするため、import 順を変えない。
+import { puppeteerBootstrapStatus } from "./puppeteer_bootstrap";
+
 import { app, BrowserWindow, shell, Menu } from "electron";
 import path from "node:path";
 import os from "node:os";
-import fs from "node:fs";
 import started from "electron-squirrel-startup";
 import installExtension, { VUEJS_DEVTOOLS } from "electron-devtools-installer";
 import { updateElectronApp, UpdateSourceType } from "update-electron-app";
@@ -30,11 +34,11 @@ log.initialize();
 setupLogger();
 app.setName(BRAND.appName);
 
-// --- Runtime Puppeteer Patch ---
-// puppeteer の CJS エントリでは exports.launch = puppeteer.launch として関数参照を
-// スナップショットしており、default インスタンスの launch を差し替えても named export
-// 側には届かない。ESM の mulmocast 等が bundler 経由で `require("puppeteer").launch`
-// を直接呼ぶケースをカバーするため、両方を同時に上書きする。
+// --- Runtime Puppeteer Patch (defense in depth) ---
+// 第一防衛線は puppeteer_bootstrap で env var を設定し、puppeteer の configuration.executablePath
+// を import 時に確定させること。本パッチはバンドル経路に応じて呼び出し形が
+// `puppeteer.launch` (default) / `require("puppeteer").launch` (named export スナップショット) の
+// どちらでも options.executablePath を確実に通すための安全網。
 const originalLaunch = puppeteer.launch.bind(puppeteer);
 const patchedLaunch: typeof puppeteer.launch = (options = {}) => {
   const finalOptions = {
@@ -56,64 +60,12 @@ puppeteer.launch = patchedLaunch;
 const puppeteerCJS = require("puppeteer") as { launch: typeof puppeteer.launch };
 puppeteerCJS.launch = patchedLaunch;
 
-GraphAILogger.log("[PUPPETEER_PATCH] Runtime patch applied (default + named export)");
-// end of Patch
-
-// Production環境でのChromiumパス設定
-if (!app.isPackaged) {
-  GraphAILogger.log("[PUPPETEER] Development environment detected, skipping Chromium path configuration");
-} else {
-  GraphAILogger.log("[PUPPETEER] Production environment detected, configuring Chromium path");
-  const chromiumDir = path.join(process.resourcesPath, "chromium", "chrome");
-  GraphAILogger.log(`[PUPPETEER] Looking for Chromium in: ${chromiumDir}`);
-
-  try {
-    const versionDirs = fs
-      .readdirSync(chromiumDir)
-      .filter((dir) => dir.startsWith("win64-") || dir.startsWith("mac-") || dir.startsWith("mac_"));
-    GraphAILogger.log(`[PUPPETEER] Found version directories: ${versionDirs.join(", ")}`);
-
-    if (versionDirs.length < 1) {
-      GraphAILogger.warn("[PUPPETEER] No Chromium version directories found");
-    } else {
-      const platform = os.platform() === "win32" ? "win64" : "mac-arm64";
-      GraphAILogger.log(`[PUPPETEER] Detected platform: ${platform}`);
-
-      const macPrefixes = ["mac-arm64-", "mac-arm-", "mac_arm-"];
-      const targetDir =
-        os.platform() === "win32"
-          ? versionDirs.find((dir) => dir.startsWith("win64-"))
-          : versionDirs.find((dir) => macPrefixes.some((prefix) => dir.startsWith(prefix)));
-      GraphAILogger.log(`[PUPPETEER] Target directory: ${targetDir || "none found"}`);
-
-      if (!targetDir) {
-        GraphAILogger.warn(`[PUPPETEER] No matching directory found for platform: ${platform}`);
-      } else {
-        const subDir = os.platform() === "win32" ? "chrome-win64" : "chrome-mac-arm64";
-        const finalPath =
-          os.platform() === "win32"
-            ? path.join(chromiumDir, targetDir, subDir, "chrome.exe")
-            : path.join(
-                chromiumDir,
-                targetDir,
-                subDir,
-                "Google Chrome for Testing.app",
-                "Contents",
-                "MacOS",
-                "Google Chrome for Testing",
-              );
-
-        if (!fs.existsSync(finalPath)) {
-          GraphAILogger.warn(`[PUPPETEER] Resolved path does not exist: ${finalPath}`);
-        }
-        process.env.PUPPETEER_EXECUTABLE_PATH = finalPath;
-        GraphAILogger.log(`[PUPPETEER] Set PUPPETEER_EXECUTABLE_PATH: ${finalPath}`);
-      }
-    }
-  } catch (error) {
-    GraphAILogger.error("[PUPPETEER] Failed to auto-detect Chromium path:", error);
-  }
-}
+// 起動時のカバレッジ確認ログ。1.0.14-rc-1 の事故は default だけ patch されて named export 側に
+// 届いていなかったケース。このログがあれば default=true / named=false で差分が即座にわかる。
+GraphAILogger.log(
+  `[PUPPETEER_PATCH] Runtime patch applied: default=${puppeteer.launch === patchedLaunch} named=${puppeteerCJS.launch === patchedLaunch}`,
+);
+GraphAILogger.log(`[PUPPETEER] Bootstrap status: ${JSON.stringify(puppeteerBootstrapStatus)}`);
 
 // Cross-platform icon path
 const iconPath =

--- a/src/main/puppeteer_bootstrap.ts
+++ b/src/main/puppeteer_bootstrap.ts
@@ -1,0 +1,74 @@
+// puppeteer の getConfiguration() は import 時に PUPPETEER_EXECUTABLE_PATH を読んで
+// configuration.executablePath にコピーし (lib/cjs/puppeteer/getConfiguration.js)、
+// その値が resolveExecutablePath() で最優先で参照される。
+// よって puppeteer (および puppeteer を間接 import するモジュール) を読み込む「前」に
+// 同梱 Chromium のパスを env var に確定させる必要がある。
+// 本ファイルは副作用 import として main.ts の最初の import に置くこと。並び替え禁止。
+
+import path from "node:path";
+import os from "node:os";
+import fs from "node:fs";
+import { app } from "electron";
+
+type BootstrapStatus =
+  | { kind: "development" }
+  | { kind: "no-chromium-dir"; chromiumDir: string }
+  | { kind: "no-version-dir"; chromiumDir: string }
+  | { kind: "no-platform-match"; chromiumDir: string; versionDirs: string[]; platform: string }
+  | { kind: "path-missing"; resolvedPath: string }
+  | { kind: "applied"; resolvedPath: string }
+  | { kind: "error"; message: string };
+
+const WIN_PLATFORM = "win32";
+const WIN_VERSION_PREFIX = "win64-";
+const WIN_SUBDIR = "chrome-win64";
+const WIN_BINARY = "chrome.exe";
+const MAC_VERSION_PREFIXES = ["mac-arm64-", "mac-arm-", "mac_arm-"];
+const MAC_VERSION_DIR_FILTER_PREFIXES = ["mac-", "mac_"];
+const MAC_SUBDIR = "chrome-mac-arm64";
+const MAC_BINARY_SEGMENTS = ["Google Chrome for Testing.app", "Contents", "MacOS", "Google Chrome for Testing"];
+
+const detect = (): BootstrapStatus => {
+  if (!app.isPackaged) return { kind: "development" };
+
+  const chromiumDir = path.join(process.resourcesPath, "chromium", "chrome");
+  try {
+    if (!fs.existsSync(chromiumDir)) {
+      return { kind: "no-chromium-dir", chromiumDir };
+    }
+
+    const versionDirs = fs
+      .readdirSync(chromiumDir)
+      .filter(
+        (dir) => dir.startsWith(WIN_VERSION_PREFIX) || MAC_VERSION_DIR_FILTER_PREFIXES.some((p) => dir.startsWith(p)),
+      );
+    if (versionDirs.length === 0) {
+      return { kind: "no-version-dir", chromiumDir };
+    }
+
+    const platform = os.platform() === WIN_PLATFORM ? "win64" : "mac-arm64";
+    const targetDir =
+      os.platform() === WIN_PLATFORM
+        ? versionDirs.find((dir) => dir.startsWith(WIN_VERSION_PREFIX))
+        : versionDirs.find((dir) => MAC_VERSION_PREFIXES.some((prefix) => dir.startsWith(prefix)));
+    if (!targetDir) {
+      return { kind: "no-platform-match", chromiumDir, versionDirs, platform };
+    }
+
+    const resolvedPath =
+      os.platform() === WIN_PLATFORM
+        ? path.join(chromiumDir, targetDir, WIN_SUBDIR, WIN_BINARY)
+        : path.join(chromiumDir, targetDir, MAC_SUBDIR, ...MAC_BINARY_SEGMENTS);
+
+    if (!fs.existsSync(resolvedPath)) {
+      return { kind: "path-missing", resolvedPath };
+    }
+
+    process.env.PUPPETEER_EXECUTABLE_PATH = resolvedPath;
+    return { kind: "applied", resolvedPath };
+  } catch (error) {
+    return { kind: "error", message: error instanceof Error ? error.message : String(error) };
+  }
+};
+
+export const puppeteerBootstrapStatus: BootstrapStatus = detect();

--- a/src/main/puppeteer_bootstrap.ts
+++ b/src/main/puppeteer_bootstrap.ts
@@ -41,7 +41,8 @@ const detect = (): BootstrapStatus => {
       .readdirSync(chromiumDir)
       .filter(
         (dir) => dir.startsWith(WIN_VERSION_PREFIX) || MAC_VERSION_DIR_FILTER_PREFIXES.some((p) => dir.startsWith(p)),
-      );
+      )
+      .sort((a, b) => b.localeCompare(a, undefined, { numeric: true }));
     if (versionDirs.length === 0) {
       return { kind: "no-version-dir", chromiumDir };
     }


### PR DESCRIPTION
## Summary
- Vite v7 → v8 (Rollup → Rolldown) への移行後、Windows 版で `puppeteer.launch(...)` のバンドル結果が puppeteer の named export 経由になり、起動時パッチが届かず同梱 Chromium への `executablePath` 注入に失敗していた問題を修正
- 影響範囲: Windows 版で HTML / Markdown / Chart / Mermaid 系ビートの画像生成が「Could not find Chrome」エラーで失敗していた

## Items to Confirm / Review
- [ ] `puppeteer_bootstrap.ts` を `main.ts` の **最初の import** として副作用 import している点（モジュール初期化順序が重要）
- [ ] `PUPPETEER_EXECUTABLE_PATH` を puppeteer の require **前**にセットしている点
- [ ] default インスタンスと named export 両方の `launch` を上書きしている点（defense in depth）
- [ ] 起動時カバレッジログ（default / named それぞれが `patchedLaunch` を指しているか）が Windows 版で出力されることの確認

## 背景
- `release/1.0.14-rc-1` の検証で発覚した bug を、`release/1.0.14-rc-2` ブランチで修正済み
- 同 fix を main 経由のレビューラインに乗せるため、本 PR で main 向けに改めて提出する
- 元コミット: `9d6ab003`（puppeteer named-export patch）+ `d14b1d31`（codex review iteration-1）

## 検証
- `yarn type-check` 通過
- Windows 版での HTML / Markdown / Chart / Mermaid 系ビート生成成功は rc-2 ビルドで確認済み

## User Prompt
> 並列実行数 UI と mulmocast 2.6.6→2.6.13 更新を含む v1.0.14 をリリース準備中。rc-1 検証で Windows 版のビート生成失敗が発覚し、rc-2 ブランチで修正済み。ただし rc-2 ブランチ上で行った修正が main の PR レビューを経ていない状態だったため、main 向けの fix PR として正規ルートで通したい。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized Puppeteer initialization in the Electron main process to improve setup sequencing and reliability.
  * Enhanced browser executable configuration to ensure proper detection and initialization across different deployment environments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/receptron/mulmocast-app/pull/1644?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->