### PR TITLE
chore: upgrade actions/cache from v4 to v5

### DIFF
--- a/.github/workflows/ci-mac.yml
+++ b/.github/workflows/ci-mac.yml
@@ -39,7 +39,7 @@ jobs:
 
       # Puppeteer Chromium cache restore (speeds up downloads)
       - name: Restore Puppeteer cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ github.workspace }}/.puppeteer-cache
           key: puppeteer-${{ runner.os }}-${{ hashFiles('yarn.lock') }}

--- a/.github/workflows/ci-ms.yml
+++ b/.github/workflows/ci-ms.yml
@@ -26,7 +26,7 @@ jobs:
 
       # Puppeteer Chromium cache restore (speeds up downloads)
       - name: Restore Puppeteer cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ github.workspace }}\\.puppeteer-cache
           key: puppeteer-${{ runner.os }}-${{ hashFiles('yarn.lock') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
 
       # Puppeteer Chromium cache restore (speeds up downloads)
       - name: Restore Puppeteer cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ github.workspace }}/.puppeteer-cache
           key: puppeteer-${{ runner.os }}-${{ hashFiles('yarn.lock') }}


### PR DESCRIPTION
## Summary
- **actions/cache v4 → v5**: Node.js 20 deprecation warning の解消

## Test plan
- [ ] CI で Node.js 20 deprecation warning が消えることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)